### PR TITLE
fix: strip unknown fields when validating model configuration request…

### DIFF
--- a/src/controllers/modelConfigController.js
+++ b/src/controllers/modelConfigController.js
@@ -46,7 +46,7 @@ async function deleteModelConfiguration(req, res, next) {
 }
 
 async function saveModelCongiguration(req,res, next) {
-    const { error, value } = modelConfigSchema.validate(req.body);
+    const { error, value } = modelConfigSchema.validate(req.body, { stripUnknown: true });
     if (error) {
         throw new Error(error.details[0].message);
     }


### PR DESCRIPTION
This pull request adds the `stripUnknown: true` option to the model configuration validation schema. This enhancement will automatically remove any unknown/undefined fields from the request body during validation, improving data integrity and preventing potential issues from unexpected fields.

**Changes:**
- Modified `saveModelCongiguration` function in `src/controllers/modelConfigController.js`
- Added `{ stripUnknown: true }` option to the `modelConfigSchema.validate()` call

**Benefits:**
- Improved input validation
- Better data consistency
- Protection against malformed requests with extra fields