### PR TITLE
feat: add openai_response and gemini as valid service options in mode…

### DIFF
--- a/src/validation/joi_validation/modelConfigValidation.js
+++ b/src/validation/joi_validation/modelConfigValidation.js
@@ -1,7 +1,7 @@
 import Joi from "joi";
 
 const modelConfigSchema = Joi.object({
-    service : Joi.string().valid('openai', 'google', 'anthropic', 'groq', 'open_router', 'mistral').optional(),
+    service : Joi.string().valid('openai','openai_response', 'gemini', 'anthropic', 'groq', 'open_router', 'mistral').optional(),
     model_name: Joi.string().pattern(/^[^\s]+$/).message('model_name must not contain spaces').required(),
     status: Joi.number().default(1),
     configuration: Joi.object().unknown(true).required(),
@@ -11,7 +11,7 @@ const modelConfigSchema = Joi.object({
 
 const UserModelConfigSchema = Joi.object({
     org_id: Joi.string().required(),
-    service: Joi.string().valid('openai', 'google', 'anthropic', 'groq', 'open_router', 'mistral').required(),
+    service: Joi.string().valid('openai','openai_response', 'gemini', 'anthropic', 'groq', 'open_router', 'mistral').required(),
     model_name: Joi.string().pattern(/^[^\s]+$/).message('model_name must not contain spaces').required(),
     display_name: Joi.string().required(),
     status: Joi.number().default(1),


### PR DESCRIPTION
This pull request adds support for two new service options in the model configuration validation:

- **openai_response**: Added as a valid service option for OpenAI response handling
- **gemini**: Added as a valid service option for Google's Gemini AI model

The changes were made to the Joi validation schema in `src/validation/joi_validation/modelConfigValidation.js` to ensure that these new service types are properly recognized and validated when creating or updating model configurations.

These additions expand the supported AI services in the middleware, allowing for better integration with OpenAI response handling and Google's Gemini model.