### PR TITLE
refactor: Change org_id validation from objectId to any in deleteBrid…

### DIFF
--- a/src/validation/joi_validation/conversation.validation.js
+++ b/src/validation/joi_validation/conversation.validation.js
@@ -74,7 +74,7 @@ const deleteBridges = {
         agent_id: Joi.objectId().required(),
     }).unknown(true),
     body: Joi.object().keys({
-        org_id: Joi.string(),
+        org_id: Joi.any(),
         restore: Joi.boolean(),
     }).unknown(true),
 };


### PR DESCRIPTION
…ges schema

- Updated org_id field validation in deleteBridges body schema to accept any type instead of restricting to objectId format.