### PR TITLE
fix: Rename endpoint_name to title in saveApi function

### DIFF
--- a/src/db_services/apiCall.service.js
+++ b/src/db_services/apiCall.service.js
@@ -166,7 +166,7 @@ async function saveApi(desc, org_id, folder_id, user_id, api_data, bridge_ids = 
         org_id: org_id,
         function_name: function_name,
         fields: fields,
-        endpoint_name: endpoint_name,
+        title: title,
         status: 1
     };
 


### PR DESCRIPTION
- Updated the saveApi function to replace the endpoint_name property with title, improving clarity in the API data structure.