### PR TITLE
Implement searchRag endpoint for querying Hippocampus API

### DIFF
--- a/src/routes/rag.routes.js
+++ b/src/routes/rag.routes.js
@@ -1,10 +1,10 @@
 import multer from 'multer';
 import express from "express";
-import { getAllDocuments, createVectors, deleteDoc, updateDoc, getEmbedToken, ragEmbedUserLogin } from "../controllers/rag.controller.js";
+import { getAllDocuments, createVectors, deleteDoc, updateDoc, getEmbedToken, ragEmbedUserLogin, searchRag } from "../controllers/rag.controller.js";
 import { EmbeddecodeToken, middleware, checkAgentAccessMiddleware } from "../middlewares/middleware.js";
 import bucketService from "../services/bucket.service.js";
 import validate from "../middlewares/validate.middleware.js";
-import { createVectorsSchema, docIdSchema, updateDocSchema } from "../validation/joi_validation/rag.validation.js";
+import { createVectorsSchema, docIdSchema, updateDocSchema, searchRagSchema } from "../validation/joi_validation/rag.validation.js";
 
 // Initialize multer for memory storage
 const storage = multer.memoryStorage();
@@ -18,5 +18,6 @@ routes.get('/docs', middleware, getAllDocuments);
 routes.delete('/docs/:id', middleware, checkAgentAccessMiddleware, validate({ params: docIdSchema }), deleteDoc);
 routes.patch('/docs/:id', middleware, checkAgentAccessMiddleware, validate({ params: docIdSchema, body: updateDocSchema }), updateDoc);
 routes.get('/get-emebed-token', middleware, getEmbedToken);
+routes.post('/search', middleware, validate({ body: searchRagSchema }), searchRag);
 
 export default routes;

--- a/src/validation/joi_validation/rag.validation.js
+++ b/src/validation/joi_validation/rag.validation.js
@@ -32,8 +32,20 @@ const updateDocSchema = Joi.object({
     description: Joi.string().optional()
 }).unknown(true);
 
+const searchRagSchema = Joi.object({
+    agent_id: Joi.string().required().messages({
+        'any.required': 'agent_id is required',
+        'string.empty': 'agent_id cannot be empty'
+    }),
+    query: Joi.string().required().messages({
+        'any.required': 'query is required',
+        'string.empty': 'query cannot be empty'
+    })
+}).unknown(true);
+
 export {
     createVectorsSchema,
     docIdSchema,
-    updateDocSchema
+    updateDocSchema,
+    searchRagSchema
 };


### PR DESCRIPTION
- Added a new controller function `searchRag` to handle search requests, validating input and making API calls to the Hippocampus service.
- Introduced `searchRagSchema` for input validation using Joi, ensuring required fields are present.
- Updated routes to include a POST endpoint for `/search`, linking it to the new controller function.
- Refactored existing imports in `rag.controller.js` and `rag.routes.js` to accommodate the new functionality.