### PR TITLE
feat: add delayed health check endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,10 +63,10 @@ app.get("/healthcheck", async (req, res) => {
   res.status(200).send("OK running good...v1.1");
 });
 
-// Delayed health check endpoint - waits 10 seconds before responding
+// Delayed health check endpoint - waits 20 seconds before responding
 app.get("/health-check-delayed", async (req, res) => {
-  await new Promise((resolve) => setTimeout(resolve, 10000));
-  res.status(200).json({ status: "ok", message: "Health check passed after 10 second delay", delay: "10s" });
+  await new Promise((resolve) => setTimeout(resolve, 20000));
+  res.status(200).json({ status: "ok", message: "Health check passed after 20 second delay", delay: "20s" });
 });
 app.use("/api/v1/config", converstaionRoutes);
 app.use("/api/agent", configRoutes);

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,12 @@ try {
 app.get("/healthcheck", async (req, res) => {
   res.status(200).send("OK running good...v1.1");
 });
+
+// Delayed health check endpoint - waits 10 seconds before responding
+app.get("/health-check-delayed", async (req, res) => {
+  await new Promise((resolve) => setTimeout(resolve, 10000));
+  res.status(200).json({ status: "ok", message: "Health check passed after 10 second delay", delay: "10s" });
+});
 app.use("/api/v1/config", converstaionRoutes);
 app.use("/api/agent", configRoutes);
 app.use("/api/history", historyRoutes);


### PR DESCRIPTION
## Summary
Adds a new health check endpoint that waits 10 seconds before responding.

## Changes
- Added `/health-check-delayed` endpoint that:
  - Waits for 10 seconds using `setTimeout`
  - Returns a JSON response with status `ok` and delay information
  - Returns HTTP 200 status

## Endpoint
```
GET /health-check-delayed
```

## Response (after 10s delay)
```json
{
  "status": "ok",
  "message": "Health check passed after 10 second delay",
  "delay": "10s"
}
```

## Why
This endpoint can be used for testing timeouts, load balancer configurations, or any scenario where a delayed response is needed for testing purposes.