### PR TITLE
feat: add 'key' parameter to getConnectedAgents API for orchestral/flow modes

### DIFF
--- a/src/controllers/agentVersion.controller.js
+++ b/src/controllers/agentVersion.controller.js
@@ -222,10 +222,10 @@ const suggestModel = async (req, res, next) => {
 
 const getConnectedAgents = async (req, res, next) => {
   const { version_id } = req.params; // Changed from 'id' to 'version_id'
-  const { type } = req.query;
+  const { type, key = "orchestral" } = req.query;
   const org_id = req.profile.org.id;
 
-  const result = await agentVersionDbService.getAllConnectedAgents(version_id, org_id, type);
+  const result = await agentVersionDbService.getAllConnectedAgents(version_id, org_id, type, key);
   res.locals = { success: true, data: result };
   req.statusCode = 200;
   return next();

--- a/src/db_services/agentVersion.service.js
+++ b/src/db_services/agentVersion.service.js
@@ -13,6 +13,19 @@ import { getReqOptVariablesInPrompt, transformAgentVariableToToolCallFormat } fr
 import { convertPromptToString } from "../utils/promptWrapper.utils.js";
 const ObjectId = mongoose.Types.ObjectId;
 
+// Constants for agent traversal modes
+const AGENT_TRAVERSAL_MODES = {
+  ORCHESTRAL: "orchestral",
+  FLOW: "flow"
+};
+
+// Constants for traversal directions
+const TRAVERSAL_DIRECTIONS = {
+  BOTH: "both",
+  CHILDREN_ONLY: "children-only",
+  PARENTS_ONLY: "parents-only"
+};
+
 async function getVersion(version_id) {
   try {
     const version = await bridgeVersionModel.findById(version_id).lean();
@@ -474,7 +487,7 @@ async function publish(org_id, version_id, user_id) {
   return { success: true, message: "Version published successfully" };
 }
 
-async function getAllConnectedAgents(id, org_id, type, key = "orchestral") {
+async function getAllConnectedAgents(id, org_id, type, key = AGENT_TRAVERSAL_MODES.ORCHESTRAL) {
   const agentsMap = {};
   const visited = new Set();
 
@@ -502,48 +515,59 @@ async function getAllConnectedAgents(id, org_id, type, key = "orchestral") {
   // Find all agents that reference a given agent as a child (i.e., find parents)
   async function findParentAgents(agentId) {
     const parents = [];
+    const agentIdStr = agentId.toString();
 
-    // Search in bridges (configurationModel) for agents that have this agent in connected_agents
-    const bridgeParents = await configurationModel
-      .find({
-        org_id,
-        $or: [{ [`connected_agents.${agentId}`]: { $exists: true } }, { "connected_agents": { $elemMatch: { $or: [{ version_id: agentId }, { bridge_id: agentId }] } } }]
-      })
-      .lean();
+    try {
+      // Search in bridges (configurationModel) for agents that have this agent in connected_agents
+      // Note: connected_agents is an Object keyed by agent name, with values containing version_id/bridge_id
+      // We query for documents with non-empty connected_agents and filter in JS
+      const bridgeParents = await configurationModel
+        .find({
+          org_id,
+          connected_agents: { $exists: true, $ne: {} }
+        })
+        .lean();
 
-    for (const parent of bridgeParents) {
-      const connectedAgents = parent.connected_agents || {};
-      for (const [, info] of Object.entries(connectedAgents)) {
-        if (info && (info.version_id === agentId || info.bridge_id === agentId)) {
-          parents.push({ id: parent._id.toString(), type: "bridge" });
-          break;
+      for (const parent of bridgeParents) {
+        const connectedAgents = parent.connected_agents || {};
+        for (const [, info] of Object.entries(connectedAgents)) {
+          if (info && (info.version_id === agentIdStr || info.bridge_id === agentIdStr)) {
+            parents.push({ id: parent._id.toString(), type: "bridge" });
+            break;
+          }
         }
       }
+    } catch (error) {
+      console.error("Error finding parent bridges:", error);
     }
 
-    // Search in versions (bridgeVersionModel) for agents that have this agent in connected_agents
-    const versionParents = await bridgeVersionModel
-      .find({
-        org_id,
-        $or: [{ [`connected_agents.${agentId}`]: { $exists: true } }, { "connected_agents": { $elemMatch: { $or: [{ version_id: agentId }, { bridge_id: agentId }] } } }]
-      })
-      .lean();
+    try {
+      // Search in versions (bridgeVersionModel) for agents that have this agent in connected_agents
+      const versionParents = await bridgeVersionModel
+        .find({
+          org_id,
+          connected_agents: { $exists: true, $ne: {} }
+        })
+        .lean();
 
-    for (const parent of versionParents) {
-      const connectedAgents = parent.connected_agents || {};
-      for (const [, info] of Object.entries(connectedAgents)) {
-        if (info && (info.version_id === agentId || info.bridge_id === agentId)) {
-          parents.push({ id: parent._id.toString(), type: "version" });
-          break;
+      for (const parent of versionParents) {
+        const connectedAgents = parent.connected_agents || {};
+        for (const [, info] of Object.entries(connectedAgents)) {
+          if (info && (info.version_id === agentIdStr || info.bridge_id === agentIdStr)) {
+            parents.push({ id: parent._id.toString(), type: "version" });
+            break;
+          }
         }
       }
+    } catch (error) {
+      console.error("Error finding parent versions:", error);
     }
 
     return parents;
   }
 
-  async function processAgent(agentId, parentIds = [], docType = null, direction = "down") {
-    const visitKey = `${agentId}-${direction}`;
+  async function processAgent(agentId, parentIds = [], docType = null, direction = TRAVERSAL_DIRECTIONS.CHILDREN_ONLY) {
+    const visitKey = `${agentId.toString()}_${direction}`;
 
     if (visited.has(visitKey)) {
       // Agent already visited in this direction, just update parent references if needed
@@ -603,17 +627,17 @@ async function getAllConnectedAgents(id, org_id, type, key = "orchestral") {
           agentsMap[agentId].childAgents.push(childId);
         }
         const childType = info.version_id ? "version" : "bridge";
-        await processAgent(childId, [agentId], childType, "down");
+        await processAgent(childId, [agentId], childType, TRAVERSAL_DIRECTIONS.CHILDREN_ONLY);
       }
     }
 
     // For "flow" key, also traverse parent agents
-    if (key === "flow" && direction !== "down-only") {
+    if (key === AGENT_TRAVERSAL_MODES.FLOW && direction !== TRAVERSAL_DIRECTIONS.CHILDREN_ONLY) {
       const parentAgentsList = await findParentAgents(agentId);
       for (const parent of parentAgentsList) {
         if (!agentsMap[parent.id]) {
           // Process parent agent (going "up")
-          await processAgent(parent.id, [], parent.type, "up");
+          await processAgent(parent.id, [], parent.type, TRAVERSAL_DIRECTIONS.PARENTS_ONLY);
         }
         // Ensure the parent-child relationship is properly set
         if (agentsMap[parent.id] && !agentsMap[parent.id].childAgents.includes(agentId)) {
@@ -627,7 +651,7 @@ async function getAllConnectedAgents(id, org_id, type, key = "orchestral") {
   }
 
   // Start processing from the given agent
-  await processAgent(id, [], type, key === "flow" ? "both" : "down");
+  await processAgent(id, [], type, key === AGENT_TRAVERSAL_MODES.FLOW ? TRAVERSAL_DIRECTIONS.BOTH : TRAVERSAL_DIRECTIONS.CHILDREN_ONLY);
 
   return agentsMap;
 }

--- a/src/db_services/agentVersion.service.js
+++ b/src/db_services/agentVersion.service.js
@@ -474,7 +474,7 @@ async function publish(org_id, version_id, user_id) {
   return { success: true, message: "Version published successfully" };
 }
 
-async function getAllConnectedAgents(id, org_id, type) {
+async function getAllConnectedAgents(id, org_id, type, key = "orchestral") {
   const agentsMap = {};
   const visited = new Set();
 
@@ -499,9 +499,55 @@ async function getAllConnectedAgents(id, org_id, type) {
     }
   }
 
-  async function processAgent(agentId, parentIds = [], docType = null) {
-    if (visited.has(agentId)) {
-      if (parentIds && agentsMap[agentId]) {
+  // Find all agents that reference a given agent as a child (i.e., find parents)
+  async function findParentAgents(agentId) {
+    const parents = [];
+
+    // Search in bridges (configurationModel) for agents that have this agent in connected_agents
+    const bridgeParents = await configurationModel
+      .find({
+        org_id,
+        $or: [{ [`connected_agents.${agentId}`]: { $exists: true } }, { "connected_agents": { $elemMatch: { $or: [{ version_id: agentId }, { bridge_id: agentId }] } } }]
+      })
+      .lean();
+
+    for (const parent of bridgeParents) {
+      const connectedAgents = parent.connected_agents || {};
+      for (const [, info] of Object.entries(connectedAgents)) {
+        if (info && (info.version_id === agentId || info.bridge_id === agentId)) {
+          parents.push({ id: parent._id.toString(), type: "bridge" });
+          break;
+        }
+      }
+    }
+
+    // Search in versions (bridgeVersionModel) for agents that have this agent in connected_agents
+    const versionParents = await bridgeVersionModel
+      .find({
+        org_id,
+        $or: [{ [`connected_agents.${agentId}`]: { $exists: true } }, { "connected_agents": { $elemMatch: { $or: [{ version_id: agentId }, { bridge_id: agentId }] } } }]
+      })
+      .lean();
+
+    for (const parent of versionParents) {
+      const connectedAgents = parent.connected_agents || {};
+      for (const [, info] of Object.entries(connectedAgents)) {
+        if (info && (info.version_id === agentId || info.bridge_id === agentId)) {
+          parents.push({ id: parent._id.toString(), type: "version" });
+          break;
+        }
+      }
+    }
+
+    return parents;
+  }
+
+  async function processAgent(agentId, parentIds = [], docType = null, direction = "down") {
+    const visitKey = `${agentId}-${direction}`;
+
+    if (visited.has(visitKey)) {
+      // Agent already visited in this direction, just update parent references if needed
+      if (parentIds && parentIds.length > 0 && agentsMap[agentId]) {
         parentIds.forEach((pid) => {
           if (!agentsMap[agentId].parentAgents.includes(pid)) {
             agentsMap[agentId].parentAgents.push(pid);
@@ -511,7 +557,7 @@ async function getAllConnectedAgents(id, org_id, type) {
       return;
     }
 
-    visited.add(agentId);
+    visited.add(visitKey);
     const { doc, type: actualType } = await fetchDocument(agentId, docType);
 
     if (!doc) {
@@ -523,17 +569,29 @@ async function getAllConnectedAgents(id, org_id, type) {
     const threadId = connectedAgentDetails.thread_id || false;
     const description = connectedAgentDetails.description;
 
-    agentsMap[agentId] = {
-      agent_name: agentName,
-      parentAgents: parentIds || [],
-      childAgents: [],
-      thread_id: threadId,
-      document_type: actualType
-    };
-    if (description) agentsMap[agentId].description = description;
+    // Initialize or update agent entry in map
+    if (!agentsMap[agentId]) {
+      agentsMap[agentId] = {
+        agent_name: agentName,
+        parentAgents: parentIds || [],
+        childAgents: [],
+        thread_id: threadId,
+        document_type: actualType
+      };
+      if (description) agentsMap[agentId].description = description;
+    } else {
+      // Update parent references if this agent already exists
+      if (parentIds && parentIds.length > 0) {
+        parentIds.forEach((pid) => {
+          if (!agentsMap[agentId].parentAgents.includes(pid)) {
+            agentsMap[agentId].parentAgents.push(pid);
+          }
+        });
+      }
+    }
 
+    // Process children (connected_agents)
     const connectedAgents = doc.connected_agents || {};
-
     for (const [, info] of Object.entries(connectedAgents)) {
       if (!info) {
         continue;
@@ -545,12 +603,31 @@ async function getAllConnectedAgents(id, org_id, type) {
           agentsMap[agentId].childAgents.push(childId);
         }
         const childType = info.version_id ? "version" : "bridge";
-        await processAgent(childId, [agentId], childType);
+        await processAgent(childId, [agentId], childType, "down");
+      }
+    }
+
+    // For "flow" key, also traverse parent agents
+    if (key === "flow" && direction !== "down-only") {
+      const parentAgentsList = await findParentAgents(agentId);
+      for (const parent of parentAgentsList) {
+        if (!agentsMap[parent.id]) {
+          // Process parent agent (going "up")
+          await processAgent(parent.id, [], parent.type, "up");
+        }
+        // Ensure the parent-child relationship is properly set
+        if (agentsMap[parent.id] && !agentsMap[parent.id].childAgents.includes(agentId)) {
+          agentsMap[parent.id].childAgents.push(agentId);
+        }
+        if (agentsMap[agentId] && !agentsMap[agentId].parentAgents.includes(parent.id)) {
+          agentsMap[agentId].parentAgents.push(parent.id);
+        }
       }
     }
   }
 
-  await processAgent(id, null, type);
+  // Start processing from the given agent
+  await processAgent(id, [], type, key === "flow" ? "both" : "down");
 
   return agentsMap;
 }

--- a/src/validation/joi_validation/bridgeVersion.validation.js
+++ b/src/validation/joi_validation/bridgeVersion.validation.js
@@ -65,7 +65,8 @@ const getConnectedAgents = {
     .unknown(true),
   query: Joi.object()
     .keys({
-      type: Joi.string().optional()
+      type: Joi.string().optional(),
+      key: Joi.string().valid("orchestral", "flow").optional().default("orchestral")
     })
     .unknown(true)
 };


### PR DESCRIPTION
## What changed
Added a new `key` query parameter to the `getConnectedAgents` API endpoint (`GET /connected-agents/:version_id`).

### New Parameter
- **key** (optional): Accepts `orchestral` (default) or `flow`

### Behavior
- **orchestral** (default): Existing behavior — returns only child agents (agents called by the given agent)
- **flow**: Returns all connected agents including:
  - Child agents (agents that the given agent calls)
  - Parent agents (agents that call the given agent)
  - All indirect connections (recursively traverses the entire connection graph)

## Why
The existing API only returned the flow of child agents. This update ensures no connected agent is missed by:
1. Preserving backward compatibility with the default `orchestral` mode
2. Adding `flow` mode that traverses both parent and child relationships
3. Using a visited set with direction tracking to prevent infinite loops while ensuring all connections are captured

## Files Changed
- `src/controllers/agentVersion.controller.js`: Added `key` parameter extraction from query
- `src/db_services/agentVersion.service.js`: Updated `getAllConnectedAgents` with bidirectional traversal logic
- `src/validation/joi_validation/bridgeVersion.validation.js`: Added `key` parameter validation

## API Usage
```
GET /agent-version/connected-agents/:version_id?key=orchestral  # existing behavior
GET /agent-version/connected-agents/:version_id?key=flow        # full connection graph
```