### PR TITLE
feat: update AI/ML service references to OpenAI and add migration script

### DIFF
--- a/migrations/mongo/20260408115846-update_ai_ml_agent.js
+++ b/migrations/mongo/20260408115846-update_ai_ml_agent.js
@@ -1,0 +1,57 @@
+/**
+ * @param db {import('mongodb').Db}
+ * @param client {import('mongodb').MongoClient}
+ * @returns {Promise<void>}
+ */
+export const up = async (db) => {
+  const filter = { service: "ai_ml" };
+  const update = {
+    $set: {
+      service: "openai",
+      "configuration.model": "gpt-5-nano"
+    }
+  };
+
+  await db.collection("configurations").updateMany(filter, update);
+  await db.collection("configuration_versions").updateMany(filter, update);
+
+  // Update fall_back.service from "ai_ml" to "openai" and fall_back.model to "gpt-5-nano"
+  const fallbackFilter = { "fall_back.service": "ai_ml" };
+  const fallbackUpdate = {
+    $set: {
+      "fall_back.service": "openai",
+      "fall_back.model": "gpt-5-nano"
+    }
+  };
+
+  await db.collection("configurations").updateMany(fallbackFilter, fallbackUpdate);
+  await db.collection("configuration_versions").updateMany(fallbackFilter, fallbackUpdate);
+};
+
+/**
+ * @param db {import('mongodb').Db}
+ * @param client {import('mongodb').MongoClient}
+ * @returns {Promise<void>}
+ */
+export const down = async (db) => {
+  const filter = { service: "openai", "configuration.model": "gpt-5-nano" };
+  const update = {
+    $set: {
+      service: "ai_ml"
+    }
+  };
+
+  await db.collection("configurations").updateMany(filter, update);
+  await db.collection("configuration_versions").updateMany(filter, update);
+
+  // Revert fall_back.service from "openai" to "ai_ml"
+  const fallbackFilter = { "fall_back.service": "openai" };
+  const fallbackUpdate = {
+    $set: {
+      "fall_back.service": "ai_ml"
+    }
+  };
+
+  await db.collection("configurations").updateMany(fallbackFilter, fallbackUpdate);
+  await db.collection("configuration_versions").updateMany(fallbackFilter, fallbackUpdate);
+};

--- a/src/configs/constant.js
+++ b/src/configs/constant.js
@@ -83,9 +83,8 @@ const new_agent_service = {
   open_router: { model: "openai/gpt-4o", default_name: "Open Router" },
   mistral: { model: "mistral-small-latest", default_name: "Mistral" },
   gemini: { model: "gemini-2.5-pro", default_name: "Gemini" },
-  ai_ml: { model: "gpt-oss-120b", default_name: "AI ML" },
   grok: { model: "grok-4-fast", default_name: "Grok" },
-  deepgram: { model: "nova-3", default_name: "Deepgram"}
+  deepgram: { model: "nova-3", default_name: "Deepgram" }
 };
 
 export { collectionNames, bridge_ids, redis_keys, cost_types, prebuilt_prompt_bridge_id, new_agent_service, embed_cache };

--- a/src/controllers/apikey.controller.js
+++ b/src/controllers/apikey.controller.js
@@ -8,7 +8,6 @@ import {
   callOpenRouterApi,
   callMistralApi,
   callGeminiApi,
-  callAiMlApi,
   callGrokApi,
   callDeepgramApi
 } from "../services/utils/aiServices.js";
@@ -239,9 +238,6 @@ const checkApikey = async (apikey, service) => {
       break;
     case "gemini":
       check = await callGeminiApi(apikey, model);
-      break;
-    case "ai_ml":
-      check = await callAiMlApi(apikey, model);
       break;
     case "grok":
       check = await callGrokApi(apikey);

--- a/src/controllers/template.controller.js
+++ b/src/controllers/template.controller.js
@@ -213,7 +213,7 @@ const createAgentFromTemplateController = async (req, res, next) => {
     model_data.prompt = model_data.prompt || prompt;
     model_data.tool_choice = "default";
 
-    const fall_back = template_content?.fall_back || { is_enable: true, service: "ai_ml", model: "gpt-oss-120b" };
+    const fall_back = template_content?.fall_back || { is_enable: true, service: "openai", model: "gpt-5.1" };
     const template_fields = [
       "variables_state",
       "built_in_tools",

--- a/src/services/utils/aiServices.js
+++ b/src/services/utils/aiServices.js
@@ -145,36 +145,6 @@ async function callGeminiApi(apiKey) {
   }
 }
 
-async function callAiMlApi(apiKey, model = "llama-3.1-8b-instruct") {
-  try {
-    const response = await fetch("https://backend.ai.ml/openai/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`
-      },
-      body: JSON.stringify({
-        model: model,
-        messages: [
-          {
-            role: "user",
-            content: "Hello!"
-          }
-        ]
-      })
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    const data = await response.json();
-    return { success: true, data };
-  } catch (error) {
-    return { success: false, error: error.message };
-  }
-}
-
 async function callGrokApi(apiKey) {
   try {
     const response = await fetch("https://api.x.ai/v1/models", {
@@ -215,14 +185,4 @@ async function callDeepgramApi(apiKey) {
   }
 }
 
-export {
-  callOpenAIModelsApi,
-  callAnthropicApi,
-  callGroqApi,
-  callOpenRouterApi,
-  callMistralApi,
-  callGeminiApi,
-  callAiMlApi,
-  callGrokApi,
-  callDeepgramApi
-};
+export { callOpenAIModelsApi, callAnthropicApi, callGroqApi, callOpenRouterApi, callMistralApi, callGeminiApi, callGrokApi, callDeepgramApi };

--- a/src/services/utils/getDefaultValue.js
+++ b/src/services/utils/getDefaultValue.js
@@ -8,7 +8,6 @@ const service_name = {
   open_router: "open_router",
   mistral: "mistral",
   gemini: "gemini",
-  ai_ml: "ai_ml",
   openai_completion: "openai_completion",
   deepgram: "deepgram"
 };

--- a/src/validation/joi_validation/agentConfig.validation.js
+++ b/src/validation/joi_validation/agentConfig.validation.js
@@ -65,7 +65,7 @@ const updateBridgeSchema = Joi.object({
   })
     .unknown(true)
     .optional(),
-  service: Joi.string().valid("openai", "anthropic", "groq", "open_router", "mistral", "gemini", "ai_ml", "grok", "deepgram").optional(),
+  service: Joi.string().valid("openai", "anthropic", "groq", "open_router", "mistral", "gemini", "grok", "deepgram").optional(),
   apikey_object_id: Joi.object()
     .pattern(Joi.string(), Joi.string().pattern(/^[0-9a-fA-F]{24}$/))
     .optional(),

--- a/src/validation/joi_validation/apikey.validation.js
+++ b/src/validation/joi_validation/apikey.validation.js
@@ -5,7 +5,7 @@ const saveApikey = {
     .keys({
       name: Joi.string().required(),
       apikey: Joi.string().required(),
-      service: Joi.string().valid("openai", "gemini", "anthropic", "groq", "open_router", "mistral", "ai_ml", "grok", "deepgram").required(),
+      service: Joi.string().valid("openai", "gemini", "anthropic", "groq", "open_router", "mistral", "grok", "deepgram").required(),
       apikey_limit: Joi.number().min(0).precision(6).optional(),
       apikey_usage: Joi.number().min(0).precision(6).optional(),
       apikey_limit_reset_period: Joi.string().valid("monthly", "weekly", "daily").optional(),
@@ -34,7 +34,7 @@ const updateApikey = {
     .keys({
       name: Joi.string().optional(),
       apikey: Joi.string().optional(),
-      service: Joi.string().valid("openai", "gemini", "anthropic", "groq", "open_router", "mistral", "ai_ml", "grok", "deepgram").optional(),
+      service: Joi.string().valid("openai", "gemini", "anthropic", "groq", "open_router", "mistral", "grok", "deepgram").optional(),
       apikey_limit: Joi.number().min(0).precision(6).optional(),
       apikey_usage: Joi.number().min(0).precision(6).optional(),
       apikey_limit_reset_period: Joi.string().valid("monthly", "weekly", "daily").optional(),

--- a/src/validation/joi_validation/modelConfig.validation.js
+++ b/src/validation/joi_validation/modelConfig.validation.js
@@ -1,7 +1,7 @@
 import Joi from "joi";
 
 const modelConfigSchema = Joi.object({
-  service: Joi.string().valid("openai", "openai_response", "gemini", "anthropic", "groq", "open_router", "mistral", "ai_ml", "deepgram").optional(),
+  service: Joi.string().valid("openai", "openai_response", "gemini", "anthropic", "groq", "open_router", "mistral", "deepgram").optional(),
   model_name: Joi.string()
     .pattern(/^[^\s]+$/)
     .message("model_name must not contain spaces")
@@ -13,7 +13,7 @@ const modelConfigSchema = Joi.object({
 }).unknown(true);
 
 const saveUserModelConfigurationBodySchema = Joi.object({
-  service: Joi.string().valid("openai", "openai_response", "gemini", "anthropic", "groq", "open_router", "mistral", "ai_ml", "deepgram").required(),
+  service: Joi.string().valid("openai", "openai_response", "gemini", "anthropic", "groq", "open_router", "mistral", "deepgram").required(),
   model_name: Joi.string()
     .pattern(/^[^\s]+$/)
     .message("model_name must not contain spaces")
@@ -29,18 +29,15 @@ const deleteUserModelConfigurationQuerySchema = Joi.object({
   model_name: Joi.string().required().messages({
     "any.required": "model_name is required"
   }),
-  service: Joi.string()
-    .valid("openai", "openai_response", "gemini", "anthropic", "groq", "open_router", "mistral", "ai_ml", "deepgram")
-    .required()
-    .messages({
-      "any.required": "service is required"
-    })
+  service: Joi.string().valid("openai", "openai_response", "gemini", "anthropic", "groq", "open_router", "mistral", "deepgram").required().messages({
+    "any.required": "service is required"
+  })
 }).unknown(true);
 
 // Legacy schema for backward compatibility
 const UserModelConfigSchema = Joi.object({
   org_id: Joi.string().required(),
-  service: Joi.string().valid("openai", "openai_response", "gemini", "anthropic", "groq", "open_router", "mistral", "ai_ml", "deepgram").required(),
+  service: Joi.string().valid("openai", "openai_response", "gemini", "anthropic", "groq", "open_router", "mistral", "deepgram").required(),
   model_name: Joi.string()
     .pattern(/^[^\s]+$/)
     .message("model_name must not contain spaces")


### PR DESCRIPTION
- Replaced occurrences of "ai_ml" with "openai" in various files, including configurations and validation schemas.
- Updated the model name to "gpt-5-nano" in the fallback configuration.
- Added a migration script to update existing database entries from "ai_ml" to "openai" and adjust related configurations accordingly.