### PR TITLE
feat: enhance log processing to save sub-thread details from various …

### DIFF
--- a/src/consumers/logQueueConsumer.js
+++ b/src/consumers/logQueueConsumer.js
@@ -18,11 +18,19 @@ import {
 import { saveMetrics, saveFlatMetrics } from "../services/logQueue/saveMetrics.service.js";
 
 async function processLogQueueMessage(messages) {
-  if (messages["save_sub_thread_id_and_name"]) {
-    await saveSubThreadIdAndName(messages["save_sub_thread_id_and_name"]);
-  }
-
   if (messages["save_history"]) {
+    const conv = messages["save_history"]?.[0]?.conversation_log_data;
+    if (conv?.sub_thread_id) {
+      await saveSubThreadIdAndName({
+        org_id: conv.org_id,
+        thread_id: conv.thread_id,
+        sub_thread_id: conv.sub_thread_id,
+        bridge_id: conv.bridge_id,
+        user: conv.user,
+        thread_flag: conv.thread_flag,
+        response_format: conv.response_format
+      });
+    }
     await saveConversationHistory(messages["save_history"]);
     await saveMetrics(messages["save_history"]);
   }
@@ -32,10 +40,26 @@ async function processLogQueueMessage(messages) {
   }
 
   if (messages["save_orchestrator_history"]) {
+    const orchestratorSubThreadData = messages["save_orchestrator_history"]?.sub_thread_data;
+    if (orchestratorSubThreadData) {
+      await saveSubThreadIdAndName(orchestratorSubThreadData);
+    }
     await saveOrchestratorHistory(messages["save_orchestrator_history"]);
   }
 
   if (messages["save_batch_history"]) {
+    const batchEntry = messages["save_batch_history"]?.[0];
+    if (batchEntry?.sub_thread_id) {
+      await saveSubThreadIdAndName({
+        org_id: batchEntry.org_id,
+        thread_id: batchEntry.thread_id,
+        sub_thread_id: batchEntry.sub_thread_id,
+        bridge_id: batchEntry.bridge_id,
+        user: batchEntry.user,
+        thread_flag: batchEntry.thread_flag,
+        response_format: batchEntry.response_format
+      });
+    }
     await saveBatchHistory(messages["save_batch_history"]);
   }
 

--- a/src/services/logQueue/saveSubThreadIdAndName.service.js
+++ b/src/services/logQueue/saveSubThreadIdAndName.service.js
@@ -6,44 +6,52 @@ import Thread from "../../mongoModel/Thread.model.js";
 import logger from "../../logger.js";
 
 async function saveSubThreadIdAndName({ thread_id, sub_thread_id, org_id, thread_flag, response_format, bridge_id, user }) {
+  const cache_key = `sub_thread_${org_id}_${bridge_id}_${thread_id}_${sub_thread_id}`;
+
   try {
-    const cache_key = `sub_thread_${org_id}_${bridge_id}_${thread_id}_${sub_thread_id}`;
+    if (await findInCache(cache_key)) return;
+  } catch (err) {
+    logger.error(`Cache lookup failed for ${cache_key}: ${err.message}`);
+  }
 
-    const cached_result = await findInCache(cache_key);
-    if (cached_result) {
-      logger.info(`Found cached sub_thread_id for key: ${cache_key}`);
-      return;
-    }
+  const current_time = new Date();
 
-    const variables = { user };
-    let display_name = sub_thread_id;
-    const current_time = new Date();
-
-    if (thread_flag) {
-      display_name = await callAiMiddleware("generate description", bridge_ids.generate_description, variables, null, "text");
-    }
-
+  try {
     await Thread.findOneAndUpdate(
       { org_id, thread_id, sub_thread_id, bridge_id },
       {
-        $set: { bridge_id, display_name: display_name || sub_thread_id },
-        $setOnInsert: { org_id, thread_id, sub_thread_id, created_at: current_time }
+        $set: { bridge_id },
+        $setOnInsert: { org_id, thread_id, sub_thread_id, display_name: sub_thread_id, created_at: current_time }
       },
       { upsert: true }
     );
+  } catch (err) {
+    logger.error(`Mongo upsert failed for sub_thread ${sub_thread_id}: ${err.message}`);
+    return;
+  }
 
-    const cache_data = {
-      org_id,
-      bridge_id,
-      thread_id,
-      sub_thread_id,
-      display_name,
-      created_at: current_time.toISOString()
-    };
-    await storeInCache(cache_key, cache_data, 172800); // 48 hours
+  let display_name = sub_thread_id;
+  if (thread_flag) {
+    try {
+      const generated = await callAiMiddleware("generate description", bridge_ids.generate_description, { user }, null, "text");
+      if (generated && generated !== sub_thread_id) {
+        display_name = generated;
+        await Thread.updateOne({ org_id, thread_id, sub_thread_id, bridge_id }, { $set: { display_name } });
+      }
+    } catch (err) {
+      logger.error(`Display-name generation failed for ${sub_thread_id}: ${err.message}`);
+    }
+  }
 
-    if (display_name && display_name !== sub_thread_id) {
-      const response = {
+  try {
+    await storeInCache(cache_key, { org_id, bridge_id, thread_id, sub_thread_id, display_name, created_at: current_time.toISOString() }, 172800);
+  } catch (err) {
+    logger.error(`Cache store failed for ${cache_key}: ${err.message}`);
+  }
+
+  if (thread_flag && display_name !== sub_thread_id) {
+    try {
+      await sendResponse(response_format, {
         data: {
           display_name,
           sub_thread_id,
@@ -51,11 +59,10 @@ async function saveSubThreadIdAndName({ thread_id, sub_thread_id, org_id, thread
           bridge_id,
           created_at: current_time.toISOString()
         }
-      };
-      await sendResponse(response_format, response);
+      });
+    } catch (err) {
+      logger.error(`sendResponse failed for ${sub_thread_id}: ${err.message}`);
     }
-  } catch (err) {
-    logger.error(`Error in saving sub thread id and name: ${err.message}`);
   }
 }
 


### PR DESCRIPTION
…message types

Updated the processLogQueueMessage function to extract and save sub-thread details from 'save_history', 'save_orchestrator_history', and 'save_batch_history' messages. Improved error handling in saveSubThreadIdAndName service for cache lookups and MongoDB operations.