### PR TITLE
feat: add optional sub_thread_id parameter to conversation createEntr…

### DIFF
--- a/src/routes/conversation.routes.js
+++ b/src/routes/conversation.routes.js
@@ -8,7 +8,7 @@ import conversationValidation from "../validation/joi_validation/conversation.va
 let router = express.Router();
 
 router.get("/threads/:thread_id/:bridge_id", middleware, validate(conversationValidation.getThreads), common.getThreads); // used by someone else
-router.post("/threads/:thread_id/:bridge_id", middleware, validate(conversationValidation.createEntry), common.createEntry); //used by some else
+router.post("/threads/:thread_id/:sub_thread_id?/:bridge_id", middleware, validate(conversationValidation.createEntry), common.createEntry); //used by some else
 router.get(
   "/history/sub-thread/:thread_id",
   middleware,

--- a/src/services/commonService/configServices.js
+++ b/src/services/commonService/configServices.js
@@ -193,7 +193,7 @@ const sendError = async (bridge_id, org_id, error_message, error_type) => {
 };
 
 export const createEntry = async (req, res, next) => {
-  const { thread_id, bridge_id } = req.params;
+  const { thread_id, bridge_id, sub_thread_id } = req.params;
   const { message } = req.body;
   const message_id = crypto.randomUUID();
   const org_id = req?.profile?.org?.id || req?.profile?.org_id;
@@ -207,7 +207,7 @@ export const createEntry = async (req, res, next) => {
     type: "chat",
     message_by: "assistant",
     message_id: message_id,
-    sub_thread_id: thread_id
+    sub_thread_id: sub_thread_id || thread_id
   };
   try {
     await createThreadHistrorySchema.validateAsync(payload);
@@ -221,7 +221,7 @@ export const createEntry = async (req, res, next) => {
 
   await createThread({
     thread_id,
-    sub_thread_id: thread_id,
+    sub_thread_id: sub_thread_id || thread_id,
     display_name: thread_id,
     org_id: org_id?.toString(),
     bridge_id

--- a/src/validation/joi_validation/conversation.validation.js
+++ b/src/validation/joi_validation/conversation.validation.js
@@ -28,7 +28,8 @@ const createEntry = {
   params: Joi.object()
     .keys({
       thread_id: Joi.string().required(),
-      bridge_id: Joi.string().required()
+      bridge_id: Joi.string().required(),
+      sub_thread_id: Joi.string().optional()
     })
     .unknown(true),
   body: Joi.object()


### PR DESCRIPTION
…y endpoint

Added sub_thread_id as an optional route parameter in POST /threads endpoint. Updated route definition, validation schema, and service logic to support sub_thread_id, falling back to thread_id when not provided.