### PR TITLE
feat: migrate connected_tools structure and consolidate tool-related …

### DIFF
--- a/migrations/mongo/20260409225100-connected_tools_migration.js
+++ b/migrations/mongo/20260409225100-connected_tools_migration.js
@@ -1,0 +1,274 @@
+/**
+ * @param db {import('mongodb').Db}
+ * @param client {import('mongodb').MongoClient}
+ * @returns {Promise<void>}
+ */
+export const up = async (db) => {
+  console.log("Starting connected_tools field migration...");
+
+  // Process configurations collection
+  await migrateCollection(db, "configurations");
+
+  // Process configuration_versions collection
+  await migrateCollection(db, "configuration_versions");
+
+  console.log("Connected_tools field migration completed successfully!");
+};
+
+/**
+ * @param db {import('mongodb').Db}
+ * @param client {import('mongodb').MongoClient}
+ * @returns {Promise<void>}
+ */
+export const down = async (db) => {
+  console.log("Rolling back connected_tools field migration...");
+
+  // Rollback configurations collection
+  await rollbackCollection(db, "configurations");
+
+  // Rollback configuration_versions collection
+  await rollbackCollection(db, "configuration_versions");
+
+  console.log("Connected_tools field rollback completed successfully!");
+};
+
+async function migrateCollection(db, collectionName) {
+  console.log(`\nProcessing ${collectionName} collection...`);
+
+  const collection = db.collection(collectionName);
+
+  // Find ALL documents in the collection
+  const documents = await collection.find({}).toArray();
+  console.log(`Found ${documents.length} total documents in ${collectionName}`);
+
+  if (documents.length === 0) {
+    console.log(`No documents found in ${collectionName}`);
+    return;
+  }
+
+  // Process in batches
+  const batchSize = 100;
+  let processedCount = 0;
+
+  for (let i = 0; i < documents.length; i += batchSize) {
+    const batch = documents.slice(i, i + batchSize);
+    const bulkOps = [];
+
+    for (const doc of batch) {
+      // Build the connected_tools object with new structure
+      const connected_tools = {};
+
+      // Transform function_ids to tools array with type and args
+      const functionIds = doc.function_ids || [];
+      connected_tools.tools = functionIds.map((id) => ({
+        id: id,
+        type: "tool",
+        args: {},
+      }));
+
+      // Transform connected_agents to include variable_path
+      const connectedAgents = doc.connected_agents || {};
+      const variablesPath = doc.variables_path || {};
+      
+      connected_tools.connected_agents = Object.entries(connectedAgents).map(([key, agent]) => ({
+        ...agent,
+        type: "agent",
+        variable_path: variablesPath[key] || {},
+      }));
+
+      // Transform built_in_tools to tools array with type
+      const builtInTools = doc.built_in_tools || [];
+      const builtInToolsArray = builtInTools.map((tool) => ({
+        id: tool,
+        type: "built_in_tool",
+        args: {},
+      }));
+      connected_tools.tools = [...connected_tools.tools, ...builtInToolsArray];
+
+      // Add web_search_filters with default if missing
+      connected_tools.web_search_filters = doc.web_search_filters || [];
+
+      // Add gtwy_web_search_filters with default if missing
+      connected_tools.gtwy_web_search_filters = doc.gtwy_web_search_filters || [];
+
+      // Transform doc_ids to docs array
+      const docIds = doc.doc_ids || [];
+      connected_tools.docs = docIds.map((id) => ({
+        id: id,
+        type: "doc",
+      }));
+
+      // Create update operation
+      const updateOp = {
+        updateOne: {
+          filter: { _id: doc._id },
+          update: {
+            $set: {
+              connected_tools: connected_tools
+            }
+          }
+        }
+      };
+
+      // Add $unset for old fields that were moved (only if they existed)
+      const unsetFields = {};
+      if (doc.function_ids !== undefined) {
+        unsetFields.function_ids = 1;
+      }
+      if (doc.built_in_tools !== undefined) {
+        unsetFields.built_in_tools = 1;
+      }
+      if (doc.variables_path !== undefined) {
+        unsetFields.variables_path = 1;
+      }
+      if (doc.doc_ids !== undefined) {
+        unsetFields.doc_ids = 1;
+      }
+      // Note: connected_agents is kept at top level, not moved to connected_tools
+
+      if (Object.keys(unsetFields).length > 0) {
+        updateOp.updateOne.update.$unset = unsetFields;
+      }
+
+      bulkOps.push(updateOp);
+    }
+
+    // Execute batch update
+    if (bulkOps.length > 0) {
+      const result = await collection.bulkWrite(bulkOps);
+      processedCount += result.modifiedCount;
+      console.log(
+        `Processed batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(documents.length / batchSize)}: ${result.modifiedCount} documents updated`
+      );
+    }
+  }
+
+  console.log(`Completed ${collectionName}: ${processedCount} documents updated`);
+
+  // Verify migration - all documents should now have connected_tools field
+  const missingConnectedToolsDocs = await collection.countDocuments({ connected_tools: { $exists: false } });
+  if (missingConnectedToolsDocs === 0) {
+    console.log(`Verification passed: All documents in ${collectionName} now have connected_tools field`);
+  } else {
+    console.log(`Verification warning: ${missingConnectedToolsDocs} documents in ${collectionName} still missing connected_tools field`);
+  }
+
+  // Check connected_tools field count
+  const connectedToolsDocs = await collection.countDocuments({ connected_tools: { $exists: true } });
+  console.log(`${collectionName} now has ${connectedToolsDocs} documents with connected_tools field`);
+}
+
+async function rollbackCollection(db, collectionName) {
+  console.log(`\nRolling back ${collectionName} collection...`);
+
+  const collection = db.collection(collectionName);
+
+  // Find all documents with connected_tools field
+  const documents = await collection.find({ connected_tools: { $exists: true } }).toArray();
+  console.log(`Found ${documents.length} documents with connected_tools in ${collectionName}`);
+
+  if (documents.length === 0) {
+    console.log(`No documents with connected_tools found in ${collectionName}`);
+    return;
+  }
+
+  // Process in batches
+  const batchSize = 100;
+  let processedCount = 0;
+
+  for (let i = 0; i < documents.length; i += batchSize) {
+    const batch = documents.slice(i, i + batchSize);
+    const bulkOps = [];
+
+    for (const doc of batch) {
+      const connected_tools = doc.connected_tools || {};
+      const setFields = {};
+      const unsetFields = { connected_tools: 1 };
+
+      // Restore function_ids from tools array
+      if (connected_tools.tools && Array.isArray(connected_tools.tools)) {
+        const functionIds = connected_tools.tools
+          .filter((tool) => tool.type === "tool")
+          .map((tool) => tool.id);
+        if (functionIds.length > 0) {
+          setFields.function_ids = functionIds;
+        }
+      }
+
+      // Restore built_in_tools from tools array
+      if (connected_tools.tools && Array.isArray(connected_tools.tools)) {
+        const builtInTools = connected_tools.tools
+          .filter((tool) => tool.type === "built_in_tool")
+          .map((tool) => tool.id);
+        if (builtInTools.length > 0) {
+          setFields.built_in_tools = builtInTools;
+        }
+      }
+
+      // Restore connected_agents and variables_path from connected_agents array
+      if (connected_tools.connected_agents && Array.isArray(connected_tools.connected_agents)) {
+        const connectedAgents = {};
+        const variablesPath = {};
+        
+        connected_tools.connected_agents.forEach((agent) => {
+          const { variable_path, type, ...agentData } = agent;
+          connectedAgents[agent.id || agent.bridge_id] = agentData;
+          if (variable_path && Object.keys(variable_path).length > 0) {
+            variablesPath[agent.id || agent.bridge_id] = variable_path;
+          }
+        });
+        
+        if (Object.keys(connectedAgents).length > 0) {
+          setFields.connected_agents = connectedAgents;
+        }
+        if (Object.keys(variablesPath).length > 0) {
+          setFields.variables_path = variablesPath;
+        }
+      }
+
+      // Restore doc_ids from docs array
+      if (connected_tools.docs && Array.isArray(connected_tools.docs)) {
+        const docIds = connected_tools.docs.map((doc) => doc.id);
+        if (docIds.length > 0) {
+          setFields.doc_ids = docIds;
+        }
+      }
+
+      // Restore web_search_filters if it exists in connected_tools
+      if (connected_tools.web_search_filters !== undefined) {
+        setFields.web_search_filters = connected_tools.web_search_filters;
+      }
+
+      // Restore gtwy_web_search_filters if it exists in connected_tools
+      if (connected_tools.gtwy_web_search_filters !== undefined) {
+        setFields.gtwy_web_search_filters = connected_tools.gtwy_web_search_filters;
+      }
+
+      const updateOp = {
+        updateOne: {
+          filter: { _id: doc._id },
+          update: {}
+        }
+      };
+
+      if (Object.keys(setFields).length > 0) {
+        updateOp.updateOne.update.$set = setFields;
+      }
+
+      updateOp.updateOne.update.$unset = unsetFields;
+
+      bulkOps.push(updateOp);
+    }
+
+    // Execute batch update
+    if (bulkOps.length > 0) {
+      const result = await collection.bulkWrite(bulkOps);
+      processedCount += result.modifiedCount;
+      console.log(
+        `Rolled back batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(documents.length / batchSize)}: ${result.modifiedCount} documents updated`
+      );
+    }
+  }
+
+  console.log(`Completed rollback for ${collectionName}: ${processedCount} documents updated`);
+}

--- a/src/controllers/agentConfig.controller.js
+++ b/src/controllers/agentConfig.controller.js
@@ -435,7 +435,7 @@ const getAgentController = async (req, res, next) => {
       variables = Helper.findVariablesInString(prompt);
     }
 
-    const variables_path = agent.bridges.variables_path || {};
+    const variables_path = agent.bridges.connected_tools?.variables_path || {};
     const path_variables = [];
     for (const key in variables_path) {
       const val = variables_path[key];

--- a/src/controllers/agentVersion.controller.js
+++ b/src/controllers/agentVersion.controller.js
@@ -72,7 +72,6 @@ const updateVersionController = async (req, res, next) => {
     const version = versionData.bridges;
     const parent_id = version.parent_id;
     const current_configuration = version.configuration || {};
-    let current_variables_path = version.variables_path || {};
     let function_ids = version.function_ids || [];
 
     const update_fields = {};
@@ -130,6 +129,105 @@ const updateVersionController = async (req, res, next) => {
       }
     }
 
+    const current_connected_tools = {
+      tools: versionData.connected_tools?.tools || [],
+      connected_agents: versionData.connected_tools?.connected_agents || [],
+      built_in_tools: versionData.connected_tools?.built_in_tools || [],
+      docs: versionData.connected_tools?.docs || [],
+      web_search_filters: versionData.connected_tools?.web_search_filters || [],
+      gtwy_web_search_filters: versionData.connected_tools?.gtwy_web_search_filters || versionData.gtwy_web_search_filters || []
+    };
+
+    const has_connected_tools_payload = body.connected_tools && typeof body.connected_tools === "object";
+    if (has_connected_tools_payload || body.gtwy_web_search_filters !== undefined) {
+      const incoming_connected_tools = {
+        ...(has_connected_tools_payload ? body.connected_tools : {})
+      };
+
+      if (body.gtwy_web_search_filters !== undefined) {
+        incoming_connected_tools.gtwy_web_search_filters = body.gtwy_web_search_filters;
+      }
+
+      const merged_connected_tools = {
+        ...current_connected_tools,
+        ...incoming_connected_tools
+      };
+
+      // Merge connected_agents array with args
+      if (incoming_connected_tools.connected_agents && Array.isArray(incoming_connected_tools.connected_agents)) {
+        const merged_agents = [...(current_connected_tools.connected_agents || [])];
+        for (const incoming_agent of incoming_connected_tools.connected_agents) {
+          const existing_idx = merged_agents.findIndex(a => a.bridge_id === incoming_agent.bridge_id);
+          if (existing_idx >= 0) {
+            merged_agents[existing_idx] = { ...merged_agents[existing_idx], ...incoming_agent };
+          } else {
+            merged_agents.push(incoming_agent);
+          }
+        }
+        merged_connected_tools.connected_agents = merged_agents;
+      }
+
+      const target_id = version_id;
+
+      if (incoming_connected_tools.function_ids !== undefined) {
+        const previous_ids = (current_connected_tools.function_ids || []).map((id) => id.toString());
+        const next_ids = (incoming_connected_tools.function_ids || []).map((id) => id.toString());
+        const added_ids = next_ids.filter((id) => !previous_ids.includes(id));
+        const removed_ids = previous_ids.filter((id) => !next_ids.includes(id));
+
+        for (const function_id of added_ids) {
+          await ConfigurationServices.updateAgentIdsInApiCalls(function_id, target_id, 1);
+        }
+        for (const function_id of removed_ids) {
+          await ConfigurationServices.updateAgentIdsInApiCalls(function_id, target_id, 0);
+        }
+
+        merged_connected_tools.function_ids = next_ids.map((id) => new ObjectId(id));
+      }
+
+      if (incoming_connected_tools.connected_agents) {
+        const { connected_agents, agent_status } = incoming_connected_tools;
+        const op = agent_status === "1" ? 1 : 0;
+
+        if (op === 0) {
+          // Remove agents from connected_agents array
+          const agent_ids = Array.isArray(connected_agents) 
+            ? connected_agents.map(a => a.bridge_id?.toString() ?? a.bridge_id)
+            : Object.values(connected_agents).map(a => a.bridge_id?.toString() ?? a.bridge_id);
+          merged_connected_tools.connected_agents = (merged_connected_tools.connected_agents || []).filter(
+            a => !agent_ids.includes(a.bridge_id?.toString() ?? a.bridge_id)
+          );
+        }
+
+        await ConfigurationServices.updateAgents(target_id, connected_agents, op);
+      }
+
+      if (incoming_connected_tools.functionData) {
+        const { function_id, function_operation, script_id } = incoming_connected_tools.functionData;
+        if (function_id) {
+          const op = function_operation === "1" ? 1 : 0;
+          const merged_function_ids = (merged_connected_tools.function_ids || []).map((fid) => fid.toString());
+
+          if (op === 1) {
+            if (!merged_function_ids.includes(function_id)) {
+              merged_function_ids.push(function_id);
+              await ConfigurationServices.updateAgentIdsInApiCalls(function_id, target_id, 1);
+            }
+          } else {
+            if (merged_function_ids.includes(function_id)) {
+              const idx = merged_function_ids.indexOf(function_id);
+              merged_function_ids.splice(idx, 1);
+              await ConfigurationServices.updateAgentIdsInApiCalls(function_id, target_id, 0);
+            }
+          }
+
+          merged_connected_tools.function_ids = merged_function_ids.map((fid) => new ObjectId(fid));
+        }
+      }
+
+      update_fields.connected_tools = merged_connected_tools;
+    }
+
     if (body.settings !== undefined) {
       const current_settings = version.settings || {};
       update_fields.settings = { ...current_settings, ...body.settings };
@@ -157,16 +255,7 @@ const updateVersionController = async (req, res, next) => {
       update_fields.configuration = { ...current_configuration, ...new_configuration };
     }
 
-    if (body.variables_path) {
-      const updated_variables_path = { ...current_variables_path, ...body.variables_path };
-      for (const key in updated_variables_path) {
-        if (Array.isArray(updated_variables_path[key])) {
-          updated_variables_path[key] = {};
-        }
-      }
-      update_fields.variables_path = updated_variables_path;
-      current_variables_path = updated_variables_path;
-    }
+    // variables_path is now stored in connected_agents[].args
 
     if (body.built_in_tools_data) {
       const { built_in_tools, built_in_tools_operation } = body.built_in_tools_data;
@@ -181,12 +270,14 @@ const updateVersionController = async (req, res, next) => {
       if (connected_agents) {
         const op = agent_status === "1" ? 1 : 0;
         if (op === 0) {
-          for (const agent_info of Object.values(connected_agents)) {
-            const key = agent_info.bridge_id?.toString() ?? agent_info.bridge_id;
-            if (key && current_variables_path[key]) {
-              delete current_variables_path[key];
-              update_fields.variables_path = current_variables_path;
-            }
+          // Remove agents from connected_agents array
+          const agent_ids = Array.isArray(connected_agents) 
+            ? connected_agents.map(a => a.bridge_id?.toString() ?? a.bridge_id)
+            : Object.values(connected_agents).map(a => a.bridge_id?.toString() ?? a.bridge_id);
+          if (update_fields.connected_tools) {
+            update_fields.connected_tools.connected_agents = (update_fields.connected_tools.connected_agents || []).filter(
+              a => !agent_ids.includes(a.bridge_id?.toString() ?? a.bridge_id)
+            );
           }
         }
         await ConfigurationServices.updateAgents(version_id, connected_agents, op);
@@ -210,15 +301,9 @@ const updateVersionController = async (req, res, next) => {
             await ConfigurationServices.updateAgentIdsInApiCalls(function_id, version_id, 1);
           }
         } else {
-          if (script_id && current_variables_path[script_id]) {
-            delete current_variables_path[script_id];
-            update_fields.variables_path = current_variables_path;
-          }
-          if (function_ids.includes(function_id)) {
-            function_ids = function_ids.filter((fid) => fid.toString() !== function_id);
-            update_fields.function_ids = function_ids.map((fid) => new ObjectId(fid));
-            await ConfigurationServices.updateAgentIdsInApiCalls(function_id, version_id, 0);
-          }
+          function_ids = function_ids.filter((fid) => fid.toString() !== function_id);
+          update_fields.function_ids = function_ids.map((fid) => new ObjectId(fid));
+          await ConfigurationServices.updateAgentIdsInApiCalls(function_id, version_id, 0);
         }
       }
     }

--- a/src/controllers/template.controller.js
+++ b/src/controllers/template.controller.js
@@ -87,8 +87,9 @@ const createTemplate = async (req, res, next) => {
 
   // Get function data for each function_id in the bridge
   const functionData = [];
-  if (bridge.function_ids && bridge.function_ids.length > 0) {
-    for (const functionId of bridge.function_ids) {
+  const bridgeFunctionIds = bridge.connected_tools?.function_ids || bridge.function_ids;
+  if (bridgeFunctionIds && bridgeFunctionIds.length > 0) {
+    for (const functionId of bridgeFunctionIds) {
       // Convert buffer to ObjectId if needed
       const id = functionId.buffer ? new ObjectId(Buffer.from(functionId.buffer)) : new ObjectId(functionId);
 
@@ -126,8 +127,9 @@ const createTemplate = async (req, res, next) => {
       let childBridge = childBridgeData.bridges;
 
       const childFunctionData = [];
-      if (childBridge.function_ids && childBridge.function_ids.length > 0) {
-        for (const functionId of childBridge.function_ids) {
+      const childBridgeFunctionIds = childBridge.connected_tools?.function_ids || childBridge.function_ids;
+      if (childBridgeFunctionIds && childBridgeFunctionIds.length > 0) {
+        for (const functionId of childBridgeFunctionIds) {
           const id = functionId.buffer ? new ObjectId(Buffer.from(functionId.buffer)) : new ObjectId(functionId);
           const functionDetails = await apiCallModel.findOne({ _id: id }, { function_name: 1 });
           if (functionDetails) childFunctionData.push(functionDetails);
@@ -139,9 +141,10 @@ const createTemplate = async (req, res, next) => {
         Object.entries(filterBridge(childBridge)?.bridge).filter(([k, v]) => v !== null && k !== "connected_agents")
       );
 
-      if (childBridge.connected_agents && Object.keys(childBridge.connected_agents).length > 0) {
+      const childBridgeConnectedAgents = childBridge.connected_tools?.connected_agents || childBridge.connected_agents;
+      if (childBridgeConnectedAgents && Object.keys(childBridgeConnectedAgents).length > 0) {
         const childAncestors = new Set([...ancestorIds, agentBridgeId]);
-        filteredBridge.child_agents = await buildConnectedAgents(childBridge.connected_agents, childAncestors);
+        filteredBridge.child_agents = await buildConnectedAgents(childBridgeConnectedAgents, childAncestors);
       }
 
       result[key] = {
@@ -154,8 +157,9 @@ const createTemplate = async (req, res, next) => {
     return result;
   };
 
-  if (bridge.connected_agents && Object.keys(bridge.connected_agents).length > 0) {
-    bridge.child_agents = await buildConnectedAgents(bridge.connected_agents, new Set([agent_id]));
+  const bridgeConnectedAgents = bridge.connected_tools?.connected_agents;
+  if (bridgeConnectedAgents && Object.keys(bridgeConnectedAgents).length > 0) {
+    bridge.child_agents = await buildConnectedAgents(bridgeConnectedAgents, new Set([agent_id]));
   }
   const user = "Validate the template";
   const isValid = await callAiMiddleware(user, bridge_ids["template_validator"], { template: bridge, templateName, email: req.profile?.user?.email });
@@ -214,14 +218,12 @@ const createAgentFromTemplateController = async (req, res, next) => {
 
     const fall_back = template_content?.settings?.fall_back || { is_enable: true, service: "openai", model: "gpt-5.1" };
     const template_fields = [
-      "variables_state",
-      "built_in_tools",
+      "connected_tools",
       "gpt_memory_context",
       "user_reference",
       "bridge_summary",
       "agent_variables",
       "actions",
-      "variables_path",
       "bridge_status",
       "starterQuestion",
       "IsstarterQuestionEnable",
@@ -269,7 +271,7 @@ const createAgentFromTemplateController = async (req, res, next) => {
     // --- Collect all unique function IDs and doc resource pairs across root + all children ---
     const collectAllResources = (content, allFunctionIds, allDocPairs) => {
       if (!content) return;
-      for (const fid of normalizeFunctionIds(content.function_ids)) allFunctionIds.add(fid);
+      for (const fid of normalizeFunctionIds(content.connected_tools?.function_ids || content.function_ids)) allFunctionIds.add(fid);
       if (Array.isArray(content.pre_tools)) {
         for (const tool of content.pre_tools) {
           if (tool.type === "custom_function" && tool.config?.function_id) {
@@ -277,8 +279,8 @@ const createAgentFromTemplateController = async (req, res, next) => {
           }
         }
       }
-      if (Array.isArray(content.doc_ids)) {
-        for (const doc of content.doc_ids) {
+      if (Array.isArray(content.connected_tools?.doc_ids || content.doc_ids)) {
+        for (const doc of content.connected_tools?.doc_ids || content.doc_ids) {
           if (doc.collection_id && doc.resource_id) {
             allDocPairs.set(`${doc.collection_id}:${doc.resource_id}`, doc);
           }
@@ -368,12 +370,12 @@ const createAgentFromTemplateController = async (req, res, next) => {
 
     // Apply to root agent — batch all updates into single DB calls
     const parent_updates = {};
-    const parent_function_ids_resolved = resolveFunctionIds(template_content?.function_ids);
-    if (parent_function_ids_resolved) parent_updates.function_ids = parent_function_ids_resolved;
+    const parent_function_ids_resolved = resolveFunctionIds(template_content?.connected_tools?.function_ids || template_content?.function_ids);
+    if (parent_function_ids_resolved) parent_updates["connected_tools.function_ids"] = parent_function_ids_resolved;
     const parent_pre_tools = resolvePreTools(template_content?.pre_tools);
     if (parent_pre_tools) parent_updates.pre_tools = parent_pre_tools;
-    const parent_doc_ids = resolveDocIds(template_content?.doc_ids);
-    if (parent_doc_ids) parent_updates.doc_ids = parent_doc_ids;
+    const parent_doc_ids = resolveDocIds(template_content?.connected_tools?.doc_ids || template_content?.doc_ids);
+    if (parent_doc_ids) parent_updates["connected_tools.doc_ids"] = parent_doc_ids;
     const parent_api_calls = resolveApiCalls(template_content?.apiCalls);
     if (parent_api_calls) parent_updates.apiCalls = parent_api_calls;
     if (Object.keys(parent_updates).length > 0) {
@@ -452,15 +454,15 @@ const createAgentFromTemplateController = async (req, res, next) => {
 
         // Batch all child agent updates into single DB calls
         const child_updates = {};
-        const child_function_ids_resolved = resolveFunctionIds(child_details.function_ids);
-        if (child_function_ids_resolved) child_updates.function_ids = child_function_ids_resolved;
+        const child_function_ids_resolved = resolveFunctionIds(child_details.connected_tools?.function_ids || child_details.function_ids);
+        if (child_function_ids_resolved) child_updates["connected_tools.function_ids"] = child_function_ids_resolved;
         const child_pre_tools = resolvePreTools(child_details.pre_tools);
         if (child_pre_tools) child_updates.pre_tools = child_pre_tools;
         if (child_details.connected_agent_details && Object.keys(child_details.connected_agent_details).length > 0) {
           child_updates.connected_agent_details = child_details.connected_agent_details;
         }
-        const child_doc_ids = resolveDocIds(child_details.doc_ids);
-        if (child_doc_ids) child_updates.doc_ids = child_doc_ids;
+        const child_doc_ids = resolveDocIds(child_details.connected_tools?.doc_ids || child_details.doc_ids);
+        if (child_doc_ids) child_updates["connected_tools.doc_ids"] = child_doc_ids;
         const child_api_calls = resolveApiCalls(child_details.apiCalls);
         if (child_api_calls) child_updates.apiCalls = child_api_calls;
         if (Object.keys(child_updates).length > 0) {
@@ -486,8 +488,8 @@ const createAgentFromTemplateController = async (req, res, next) => {
       }
 
       if (Object.keys(connected_agents).length > 0) {
-        await ConfigurationServices.updateAgent(parent_bridge_id, { connected_agents });
-        await ConfigurationServices.updateAgent(null, { connected_agents }, parent_version_id);
+        await ConfigurationServices.updateAgent(parent_bridge_id, { "connected_tools.connected_agents": connected_agents });
+        await ConfigurationServices.updateAgent(null, { "connected_tools.connected_agents": connected_agents }, parent_version_id);
       }
     };
 

--- a/src/db_services/agentVersion.service.js
+++ b/src/db_services/agentVersion.service.js
@@ -81,9 +81,14 @@ async function getVersionWithTools(version_id) {
     const pipeline = [
       { $match: { _id: new ObjectId(version_id) } },
       {
+        $addFields: {
+          function_ids_for_lookup: { $ifNull: ["$connected_tools.function_ids", "$function_ids"] }
+        }
+      },
+      {
         $lookup: {
           from: "apicalls",
-          localField: "function_ids",
+          localField: "function_ids_for_lookup",
           foreignField: "_id",
           as: "apiCalls"
         }
@@ -93,7 +98,7 @@ async function getVersionWithTools(version_id) {
           _id: { $toString: "$_id" },
           function_ids: {
             $map: {
-              input: "$function_ids",
+              input: "$function_ids_for_lookup",
               as: "fid",
               in: { $toString: "$$fid" }
             }
@@ -160,9 +165,9 @@ async function _cleanupConnectedAgents(version_id, org_id) {
   const affectedIds = { versions: new Set(), bridges: new Set() };
 
   // Cleanup agents
-  const agents = await configurationModel.find({ org_id, connected_agents: { $exists: true } });
+  const agents = await configurationModel.find({ org_id, "connected_tools.connected_agents": { $exists: true } });
   for (const agent of agents) {
-    const connectedAgents = agent.connected_agents || {};
+    const connectedAgents = agent.connected_tools?.connected_agents || {};
     let modified = false;
     const newAgents = {};
 
@@ -175,15 +180,15 @@ async function _cleanupConnectedAgents(version_id, org_id) {
     }
 
     if (modified) {
-      await configurationModel.updateOne({ _id: agent._id }, { $set: { connected_agents: newAgents } });
+      await configurationModel.updateOne({ _id: agent._id }, { $set: { "connected_tools.connected_agents": newAgents } });
       affectedIds.bridges.add(agent._id.toString());
     }
   }
 
   // Cleanup versions
-  const versions = await bridgeVersionModel.find({ org_id, connected_agents: { $exists: true } });
+  const versions = await bridgeVersionModel.find({ org_id, "connected_tools.connected_agents": { $exists: true } });
   for (const version of versions) {
-    const connectedAgents = version.connected_agents || {};
+    const connectedAgents = version.connected_tools?.connected_agents || {};
     let modified = false;
     const newAgents = {};
 
@@ -196,7 +201,7 @@ async function _cleanupConnectedAgents(version_id, org_id) {
     }
 
     if (modified) {
-      await bridgeVersionModel.updateOne({ _id: version._id }, { $set: { connected_agents: newAgents } });
+      await bridgeVersionModel.updateOne({ _id: version._id }, { $set: { "connected_tools.connected_agents": newAgents } });
       affectedIds.versions.add(version._id.toString());
     }
   }
@@ -233,7 +238,7 @@ async function _cleanupTestcaseHistory(version_id) {
 
 function _collectRagCacheKeys(version_doc) {
   const cacheKeys = new Set();
-  const docIds = version_doc.doc_ids || [];
+  const docIds = version_doc.connected_tools?.doc_ids || version_doc.doc_ids || [];
   docIds.forEach((docId) => {
     if (typeof docId === "string") {
       cacheKeys.add(`${redis_keys["files_"]}${docId}`);
@@ -395,7 +400,7 @@ async function publish(org_id, version_id, user_id) {
   // Extract agent variables logic
   const prompt = convertPromptToString(getVersionData.configuration?.prompt || "");
   const variableState = getVersionData.variables_state || {};
-  const variablePath = getVersionData.variables_path || {};
+  const variablePath = getVersionData.connected_tools?.variables_path || getVersionData.variables_path || {};
 
   if (Array.isArray(getVersionData.pre_tools)) {
     getVersionData.pre_tools.forEach((tool) => {
@@ -429,8 +434,8 @@ async function publish(org_id, version_id, user_id) {
     updatedConfiguration.settings.publicAgentConfig = publicAgentConfig;
   }
 
-  if (updatedConfiguration.function_ids) {
-    updatedConfiguration.function_ids = updatedConfiguration.function_ids.map((fid) => new ObjectId(fid));
+  if (updatedConfiguration.connected_tools?.function_ids) {
+    updatedConfiguration.connected_tools.function_ids = updatedConfiguration.connected_tools.function_ids.map((fid) => new ObjectId(fid));
   }
 
   // Update connected_agent_details with agent variables
@@ -548,7 +553,7 @@ async function getAllConnectedAgents(id, org_id, type) {
     };
     if (description) agentsMap[agentId].description = description;
 
-    const connectedAgents = doc.connected_agents || {};
+    const connectedAgents = doc.connected_tools?.connected_agents || doc.connected_agents || {};
 
     for (const [, info] of Object.entries(connectedAgents)) {
       if (!info) {

--- a/src/db_services/apiCall.service.js
+++ b/src/db_services/apiCall.service.js
@@ -62,11 +62,11 @@ async function deleteFunctionFromApicallsDb(org_id, script_id) {
   const function_id = bridgeData._id;
 
   if (bridge_ids.length > 0) {
-    await versionModel.updateMany({ _id: { $in: bridge_ids } }, { $pull: { function_ids: function_id } });
+    await versionModel.updateMany({ _id: { $in: bridge_ids } }, { $pull: { "connected_tools.function_ids": function_id } });
   }
 
   if (version_ids.length > 0) {
-    await versionModel.updateMany({ _id: { $in: version_ids } }, { $pull: { function_ids: function_id } });
+    await versionModel.updateMany({ _id: { $in: version_ids } }, { $pull: { "connected_tools.function_ids": function_id } });
   }
 
   const result = await apiCallModel.deleteOne({

--- a/src/db_services/configuration.service.js
+++ b/src/db_services/configuration.service.js
@@ -84,9 +84,11 @@ const cloneAgentToOrg = async (agent_id, to_shift_org_id, cloned_agents_map = nu
     await configurationModel.updateOne({ _id: new_agent_id }, { $set: update_data });
 
     // Step 6: Clone related API calls (functions) using external API
+    const original_connected_tools = original_config.connected_tools || {};
+    const original_function_ids = original_connected_tools.function_ids || original_config.function_ids || [];
     const cloned_function_ids = [];
-    if (original_config.function_ids && original_config.function_ids.length > 0) {
-      for (const function_id of original_config.function_ids) {
+    if (original_function_ids && original_function_ids.length > 0) {
+      for (const function_id of original_function_ids) {
         const original_api_call = await apiCallModel.findOne({ _id: new ObjectId(function_id) }).lean();
         if (original_api_call && original_api_call.script_id) {
           try {
@@ -141,10 +143,10 @@ const cloneAgentToOrg = async (agent_id, to_shift_org_id, cloned_agents_map = nu
 
     // Step 7: Update configuration and versions with cloned function IDs
     if (cloned_function_ids.length > 0) {
-      await configurationModel.updateOne({ _id: new_agent_id }, { $set: { function_ids: cloned_function_ids } });
+      await configurationModel.updateOne({ _id: new_agent_id }, { $set: { "connected_tools.function_ids": cloned_function_ids } });
 
       for (const version_id of cloned_version_ids) {
-        await versionModel.updateOne({ _id: new ObjectId(version_id) }, { $set: { function_ids: cloned_function_ids } });
+        await versionModel.updateOne({ _id: new ObjectId(version_id) }, { $set: { "connected_tools.function_ids": cloned_function_ids } });
       }
     }
 
@@ -152,8 +154,9 @@ const cloneAgentToOrg = async (agent_id, to_shift_org_id, cloned_agents_map = nu
     const cloned_connected_agents = {};
     const connected_agents_info = [];
 
-    if (original_config.connected_agents) {
-      for (const [, agent_info] of Object.entries(original_config.connected_agents)) {
+    const original_connected_agents = original_connected_tools.connected_agents || original_config.connected_agents || {};
+    if (original_connected_agents) {
+      for (const [, agent_info] of Object.entries(original_connected_agents)) {
         const connected_agent_id = agent_info.bridge_id;
         if (connected_agent_id) {
           try {
@@ -179,9 +182,10 @@ const cloneAgentToOrg = async (agent_id, to_shift_org_id, cloned_agents_map = nu
     // Check for connected_agents in versions and update them too
     for (const version_id of cloned_version_ids) {
       const original_version = await versionModel.findOne({ _id: new ObjectId(version_id) }).lean();
-      if (original_version && original_version.connected_agents) {
+      const version_connected_agents_data = original_version?.connected_tools?.connected_agents || original_version?.connected_agents;
+      if (original_version && version_connected_agents_data) {
         const version_connected_agents = {};
-        for (const [, v_agent_info] of Object.entries(original_version.connected_agents)) {
+        for (const [, v_agent_info] of Object.entries(version_connected_agents_data)) {
           const old_id = v_agent_info.bridge_id;
           const matched = connected_agents_info.find((c) => c.original_bridge_id === old_id);
           if (matched) {
@@ -193,21 +197,25 @@ const cloneAgentToOrg = async (agent_id, to_shift_org_id, cloned_agents_map = nu
         }
 
         if (Object.keys(version_connected_agents).length > 0) {
-          await versionModel.updateOne({ _id: new ObjectId(version_id) }, { $set: { connected_agents: version_connected_agents } });
+          await versionModel.updateOne({ _id: new ObjectId(version_id) }, { $set: { "connected_tools.connected_agents": version_connected_agents } });
         }
       }
     }
 
     if (Object.keys(cloned_connected_agents).length > 0) {
-      await configurationModel.updateOne({ _id: new_agent_id }, { $set: { connected_agents: cloned_connected_agents } });
+      await configurationModel.updateOne({ _id: new_agent_id }, { $set: { "connected_tools.connected_agents": cloned_connected_agents } });
     }
 
     // Step 9: Get the final cloned configuration
     const cloned_config = await configurationModel.findOne({ _id: new_agent_id }).lean();
     cloned_config._id = cloned_config._id.toString();
 
-    if (cloned_config.function_ids) {
-      cloned_config.function_ids = cloned_config.function_ids.map((fid) => fid.toString());
+    const cloned_config_function_ids = cloned_config.connected_tools?.function_ids || cloned_config.function_ids;
+    if (cloned_config_function_ids) {
+      cloned_config.connected_tools = {
+        ...(cloned_config.connected_tools || {}),
+        function_ids: cloned_config_function_ids.map((fid) => fid.toString())
+      };
     }
 
     return {
@@ -278,7 +286,7 @@ const deleteAgent = async (agent_id, org_id) => {
         {
           $match: {
             org_id: org_id,
-            connected_agents: { $exists: true, $ne: null }
+            "connected_tools.connected_agents": { $exists: true, $ne: null }
           }
         },
         {
@@ -286,7 +294,7 @@ const deleteAgent = async (agent_id, org_id) => {
             hasConnection: {
               $anyElementTrue: {
                 $map: {
-                  input: { $objectToArray: "$connected_agents" },
+                  input: { $objectToArray: { $ifNull: ["$connected_tools.connected_agents", {}] } },
                   as: "agent",
                   in: { $eq: ["$$agent.v.bridge_id", agent_id] }
                 }
@@ -308,7 +316,7 @@ const deleteAgent = async (agent_id, org_id) => {
         {
           $match: {
             org_id: org_id,
-            connected_agents: { $exists: true, $ne: null }
+            "connected_tools.connected_agents": { $exists: true, $ne: null }
           }
         },
         {
@@ -316,7 +324,7 @@ const deleteAgent = async (agent_id, org_id) => {
             hasConnection: {
               $anyElementTrue: {
                 $map: {
-                  input: { $objectToArray: "$connected_agents" },
+                  input: { $objectToArray: { $ifNull: ["$connected_tools.connected_agents", {}] } },
                   as: "agent",
                   in: { $eq: ["$$agent.v.bridge_id", agent_id] }
                 }
@@ -759,7 +767,7 @@ const getAgentsByUserId = async (orgId, userId, agent_id) => {
       "configuration.type": 1,
       bridgeType: 1,
       slugName: 1,
-      variables_state: 1,
+      connected_tools: 1,
       meta: 1,
       deletedAt: 1
     });
@@ -829,7 +837,7 @@ const getAgents = async (agent_id, org_id = null, version_id = null) => {
           _id: { $toString: "$_id" },
           function_ids: {
             $map: {
-              input: "$function_ids",
+              input: { $ifNull: "$connected_tools.function_ids" },
               as: "fid",
               in: { $toString: "$$fid" }
             }
@@ -991,9 +999,9 @@ const getAgentsWithoutTools = async (agent_id, org_id, version_id = null) => {
 const updateBuiltInTools = async (version_id, tool, add = 1) => {
   const to_update = { $set: { status: 1 } };
   if (add === 1) {
-    to_update.$addToSet = { built_in_tools: tool };
+    to_update.$addToSet = { "connected_tools.built_in_tools": tool };
   } else {
-    to_update.$pull = { built_in_tools: tool };
+    to_update.$pull = { "connected_tools.built_in_tools": tool };
   }
 
   const data = await versionModel.findOneAndUpdate({ _id: new ObjectId(version_id) }, to_update, {
@@ -1008,8 +1016,11 @@ const updateBuiltInTools = async (version_id, tool, add = 1) => {
     };
   }
 
-  if (!data.built_in_tools) {
-    data.built_in_tools = [];
+  if (!data.connected_tools) {
+    data.connected_tools = {};
+  }
+  if (!data.connected_tools.built_in_tools) {
+    data.connected_tools.built_in_tools = [];
   }
 
   return data;
@@ -1024,7 +1035,7 @@ const updateAgents = async (version_id, agents, add = 1) => {
       const key = agent_info.bridge_id?.toString() ?? agent_info.bridge_id;
       if (!key) continue;
       if (agent_info.thread_id === undefined) agent_info.thread_id = true;
-      setFields[`connected_agents.${key}`] = { ...agent_info };
+      setFields[`connected_tools.connected_agents.${key}`] = { ...agent_info };
     }
     to_update = { $set: setFields };
   } else {
@@ -1032,7 +1043,7 @@ const updateAgents = async (version_id, agents, add = 1) => {
     const unsetFields = {};
     for (const [, agent_info] of Object.entries(agents)) {
       const key = agent_info.bridge_id?.toString() ?? agent_info.bridge_id;
-      if (key) unsetFields[`connected_agents.${key}`] = "";
+      if (key) unsetFields[`connected_tools.connected_agents.${key}`] = "";
     }
     to_update = { $unset: unsetFields };
   }
@@ -1046,8 +1057,11 @@ const updateAgents = async (version_id, agents, add = 1) => {
     throw new Error("No records updated or version not found");
   }
 
-  if (!data.connected_agents) {
-    data.connected_agents = {};
+  if (!data.connected_tools) {
+    data.connected_tools = {};
+  }
+  if (!data.connected_tools.connected_agents) {
+    data.connected_tools.connected_agents = {};
   }
 
   return data;
@@ -1162,9 +1176,14 @@ const getAgentsWithTools = async (agent_id, org_id, version_id = null) => {
         }
       },
       {
+        $addFields: {
+          function_ids_for_lookup: { $ifNull: ["$connected_tools.function_ids", "$function_ids"] }
+        }
+      },
+      {
         $lookup: {
           from: "apicalls",
-          localField: "function_ids",
+          localField: "function_ids_for_lookup",
           foreignField: "_id",
           as: "apiCalls"
         }
@@ -1174,7 +1193,7 @@ const getAgentsWithTools = async (agent_id, org_id, version_id = null) => {
           _id: { $toString: "$_id" },
           function_ids: {
             $map: {
-              input: "$function_ids",
+              input: "$function_ids_for_lookup",
               as: "fid",
               in: { $toString: "$$fid" }
             }
@@ -1268,11 +1287,9 @@ const getAllAgentsInOrg = async (org_id, folder_id, user_id, isEmbedUser) => {
       versions: 1,
       published_version_id: 1,
       total_tokens: 1,
-      variables_state: 1,
+      connected_tools: 1,
       agent_variables: 1,
       bridge_status: 1,
-      connected_agents: 1,
-      function_ids: 1,
       connected_agent_details: 1,
       bridge_summary: 1,
       deletedAt: 1,
@@ -1281,7 +1298,6 @@ const getAllAgentsInOrg = async (org_id, folder_id, user_id, isEmbedUser) => {
       bridge_limit_reset_period: 1,
       bridge_limit_start_date: 1,
       last_used: 1,
-      variables_path: 1,
       users: 1,
       createdAt: 1,
       updatedAt: 1,
@@ -1298,6 +1314,10 @@ const getAllAgentsInOrg = async (org_id, folder_id, user_id, isEmbedUser) => {
   const processedAgents = agents.map((agent) => {
     agent._id = agent._id.toString();
     agent.bridge_id = agent._id; // Alias _id as bridge_id
+    agent.function_ids = agent.connected_tools?.function_ids || [];
+    if (agent.connected_tools?.function_ids) {
+      agent.connected_tools.function_ids = agent.connected_tools.function_ids.map((id) => id.toString());
+    }
     if (agent.function_ids) {
       agent.function_ids = agent.function_ids.map((id) => id.toString());
     }

--- a/src/mongoModel/BridgeVersion.model.js
+++ b/src/mongoModel/BridgeVersion.model.js
@@ -17,6 +17,41 @@ const actionTypeModel = new Schema(
     _id: false
   }
 );
+
+const connectedToolsSchema = new Schema(
+  {
+    function_ids: {
+      type: [mongoose.Schema.Types.ObjectId],
+      default: []
+    },
+    connected_agents: {
+      type: Object,
+      default: {}
+    },
+    built_in_tools: {
+      type: Array,
+      default: []
+    },
+    variables_path: {
+      type: Object,
+      default: {}
+    },
+    web_search_filters: {
+      type: [String],
+      default: []
+    },
+    gtwy_web_search_filters: {
+      type: [String],
+      default: []
+    },
+    doc_ids: {
+      type: Array,
+      default: []
+    }
+  },
+  { _id: false }
+);
+
 const version = new mongoose.Schema({
   org_id: {
     type: String,
@@ -61,15 +96,11 @@ const version = new mongoose.Schema({
     type: String,
     default: null
   },
+  connected_tools: {
+    type: connectedToolsSchema,
+    default: () => ({})
+  },
   variables_state: {
-    type: Object,
-    default: {}
-  },
-  function_ids: {
-    type: [mongoose.Schema.Types.ObjectId],
-    default: []
-  },
-  variables_path: {
     type: Object,
     default: {}
   },
@@ -92,10 +123,6 @@ const version = new mongoose.Schema({
   version_description: {
     type: String,
     default: ""
-  },
-  doc_ids: {
-    type: Array,
-    default: []
   },
   pre_tools: {
     type: Array,
@@ -154,10 +181,6 @@ const version = new mongoose.Schema({
   },
   hello_id: {
     type: String
-  },
-  connected_agents: {
-    type: Object,
-    default: {}
   },
   deletedAt: {
     type: Date,

--- a/src/mongoModel/Configuration.model.js
+++ b/src/mongoModel/Configuration.model.js
@@ -18,6 +18,40 @@ const actionTypeModel = new Schema(
   }
 );
 
+const connectedToolsSchema = new Schema(
+  {
+    function_ids: {
+      type: Array,
+      default: []
+    },
+    connected_agents: {
+      type: Object,
+      default: {}
+    },
+    built_in_tools: {
+      type: Array,
+      default: []
+    },
+    variables_path: {
+      type: Object,
+      default: {}
+    },
+    web_search_filters: {
+      type: [String],
+      default: []
+    },
+    gtwy_web_search_filters: {
+      type: [String],
+      default: []
+    },
+    doc_ids: {
+      type: Array,
+      default: []
+    }
+  },
+  { _id: false }
+);
+
 const configuration = new mongoose.Schema({
   org_id: {
     type: String,
@@ -77,9 +111,9 @@ const configuration = new mongoose.Schema({
     type: String,
     default: null
   },
-  variables_path: {
-    type: Object,
-    default: {}
+  connected_tools: {
+    type: connectedToolsSchema,
+    default: () => ({})
   },
   variables_state: {
     type: Object,
@@ -93,17 +127,21 @@ const configuration = new mongoose.Schema({
     type: String,
     default: ""
   },
-  connected_agents: {
+  guardrails: {
     type: Object,
-    default: {}
+    default: {
+      is_enabled: false,
+      guardrails_configuration: {},
+      guardrails_custom_prompt: ""
+    }
   },
-  doc_ids: {
-    type: Array,
-    default: []
-  },
-  built_in_tools: {
-    type: Array,
-    default: []
+  fall_back: {
+    type: Object,
+    default: {
+      is_enable: false,
+      service: "",
+      model: ""
+    }
   },
   bridge_summary: {
     type: String,
@@ -120,10 +158,6 @@ const configuration = new mongoose.Schema({
   bridge_status: {
     type: Number,
     default: 1
-  },
-  function_ids: {
-    type: Array,
-    default: []
   },
   agent_variables: {
     type: Object,

--- a/src/validation/joi_validation/agentConfig.validation.js
+++ b/src/validation/joi_validation/agentConfig.validation.js
@@ -25,7 +25,6 @@ const updateBridgeSchema = Joi.object({
   bridge_limit: Joi.number().min(0).optional(),
   bridge_limit_reset_period: Joi.string().valid("monthly", "weekly", "daily").optional(),
   bridgeType: Joi.string().valid("api", "chatbot").optional(),
-  page_config: Joi.object().optional(),
   connected_agent_details: Joi.object().optional(),
   settings: Joi.object({
     publicUsers: Joi.array().items(Joi.string()).optional(),
@@ -45,12 +44,10 @@ const updateBridgeSchema = Joi.object({
   web_search_filters: Joi.alternatives().try(Joi.array().items(Joi.string()), Joi.object()).optional(),
   gtwy_web_search_filters: Joi.alternatives().try(Joi.array().items(Joi.string()), Joi.object()).optional(),
   bridge_limit_start_date: Joi.date().optional(),
-  variables_path: Joi.object().optional(),
-  built_in_tools_data: Joi.object({
-    built_in_tools: Joi.string().optional(),
-    built_in_tools_operation: Joi.string().valid("0", "1").optional()
-  }).optional(),
-  agents: Joi.object({
+  connected_tools: Joi.object({
+    function_ids: Joi.array()
+      .items(Joi.string().pattern(/^[0-9a-fA-F]{24}$/))
+      .optional(),
     connected_agents: Joi.object()
       .pattern(
         Joi.string(),
@@ -61,15 +58,14 @@ const updateBridgeSchema = Joi.object({
         })
       )
       .optional(),
-    agent_status: Joi.string().valid("0", "1").optional()
+    agent_status: Joi.string().valid("0", "1").optional(),
+    built_in_tools: Joi.array().items(Joi.string()).optional(),
+    doc_ids: Joi.array().items(Joi.string()).optional(),
+    variables_path: Joi.object().optional(),
+    web_search_filters: Joi.alternatives().try(Joi.array().items(Joi.string()), Joi.object()).optional(),
+    gtwy_web_search_filters: Joi.alternatives().try(Joi.array().items(Joi.string()), Joi.object()).optional()
   }).optional(),
-  functionData: Joi.object({
-    function_id: Joi.string()
-      .pattern(/^[0-9a-fA-F]{24}$/)
-      .optional(),
-    function_operation: Joi.string().valid("0", "1").optional(),
-    script_id: Joi.string().optional()
-  }).optional(),
+  variables_state: Joi.object().optional(),
   version_description: Joi.string().allow("").optional()
 });
 


### PR DESCRIPTION
…fields into unified schema

Add MongoDB migration to restructure tool-related fields into a unified connected_tools object. Transform function_ids, built_in_tools, doc_ids, and variables_path into standardized arrays with type annotations. Update controllers to read from new connected_tools structure while maintaining backward compatibility during migration.