### PR TITLE
refactor: add agent_info support to updateAgentController and validat…

### DIFF
--- a/src/controllers/agentConfig.controller.js
+++ b/src/controllers/agentConfig.controller.js
@@ -282,23 +282,16 @@ const updateAgentController = async (req, res, next) => {
     const update_fields = {};
     const user_history = [];
 
-    const simpleAgentFields = [
-      "name",
-      "slugName",
-      "meta",
-      "bridge_summary",
-      "bridge_status",
-      "bridge_usage",
-      "bridge_limit",
-      "bridgeType",
-      "page_config",
-      "connected_agent_details"
-    ];
+    const simpleAgentFields = ["name", "slugName", "meta", "bridge_summary", "bridge_status", "bridge_usage", "bridge_limit", "bridgeType"];
 
     for (const field of simpleAgentFields) {
       if (body[field] !== undefined) {
         update_fields[field] = body[field];
       }
+    }
+
+    if (body.agent_info) {
+      update_fields.agent_info = { ...agent.agent_info, ...body.agent_info };
     }
 
     if (body.bridge_limit_reset_period !== undefined) {

--- a/src/validation/joi_validation/agentConfig.validation.js
+++ b/src/validation/joi_validation/agentConfig.validation.js
@@ -70,7 +70,17 @@ const updateBridgeSchema = Joi.object({
     function_operation: Joi.string().valid("0", "1").optional(),
     script_id: Joi.string().optional()
   }).optional(),
-  version_description: Joi.string().allow("").optional()
+  version_description: Joi.string().allow("").optional(),
+  agent_info: Joi.object({
+    prompt_total_tokens: Joi.number().min(0).optional(),
+    description: Joi.string().allow("").optional(),
+    agent_variables: Joi.object({
+      fields: Joi.object().optional(),
+      required: Joi.array().optional()
+    }).optional(),
+    thread_id: Joi.boolean().optional(),
+    variables_state: Joi.object().optional()
+  }).optional()
 });
 
 const bridgeIdParamSchema = Joi.object({


### PR DESCRIPTION
…ion schema

Removed page_config and connected_agent_details from simpleAgentFields array. Added agent_info object handling with merge logic in updateAgentController. Updated validation schema to include agent_info with nested fields for prompt_total_tokens, description, agent_variables, thread_id, and variables_state.