### PR TITLE
fix: skip already-migrated documents in agent_info migration and expa…

### DIFF
--- a/migrations/mongo/20260409224600-agent_info_migration.js
+++ b/migrations/mongo/20260409224600-agent_info_migration.js
@@ -37,8 +37,12 @@ async function migrateCollection(db, collectionName) {
 
   const collection = db.collection(collectionName);
 
-  // Find ALL documents in the collection
-  const documents = await collection.find({}).toArray();
+  // Find documents that don't have agent_info yet
+  const documents = await collection
+    .find({
+      agent_info: { $exists: false }
+    })
+    .toArray();
   console.log(`Found ${documents.length} total documents in ${collectionName}`);
 
   if (documents.length === 0) {
@@ -55,11 +59,6 @@ async function migrateCollection(db, collectionName) {
     const bulkOps = [];
 
     for (const doc of batch) {
-      // Skip if agent_info already exists
-      if (doc.agent_info !== undefined) {
-        continue;
-      }
-
       // Build the agent_info object with schema defaults and existing values
       const agent_info = {
         prompt_total_tokens: doc.prompt_total_tokens || 0,

--- a/migrations/mongo/20260409224600-agent_info_migration.js
+++ b/migrations/mongo/20260409224600-agent_info_migration.js
@@ -55,6 +55,11 @@ async function migrateCollection(db, collectionName) {
     const bulkOps = [];
 
     for (const doc of batch) {
+      // Skip if agent_info already exists
+      if (doc.agent_info !== undefined) {
+        continue;
+      }
+
       // Build the agent_info object with schema defaults and existing values
       const agent_info = {
         prompt_total_tokens: doc.prompt_total_tokens || 0,

--- a/src/db_services/configuration.service.js
+++ b/src/db_services/configuration.service.js
@@ -1300,7 +1300,7 @@ const getAllAgentsInOrg = async (org_id, folder_id, user_id, isEmbedUser) => {
       users: 1,
       createdAt: 1,
       updatedAt: 1,
-      "agent_info.prompt_total_tokens": 1,
+      agent_info: 1,
       "ai_updates.prompt_enhancer_percentage": 1,
       "ai_updates.criteria_check": 1,
       settings: 1,


### PR DESCRIPTION
…nd projection in getAllAgentsInOrg

Added guard clause to skip documents where agent_info already exists during migration batch processing. Changed projection from specific agent_info.prompt_total_tokens field to entire agent_info object in getAllAgentsInOrg query.