### PR TITLE
fix: faulty schema passed in json schema validation

### DIFF
--- a/src/services/utils/openaiSchemaValidator.utils.js
+++ b/src/services/utils/openaiSchemaValidator.utils.js
@@ -20,6 +20,8 @@ const ALLOWED_KEYWORDS = new Set([
   "format"
 ]);
 
+const ALLOWED_TYPES = new Set(["object", "array", "string", "number", "integer", "boolean", "null"]);
+
 function walkSchema(node, path, errors, defs, anyOfDepth, propCount, visited = new Set()) {
   if (!node || typeof node !== "object") return;
 
@@ -31,15 +33,19 @@ function walkSchema(node, path, errors, defs, anyOfDepth, propCount, visited = n
   }
 
   // Handle $ref
-  if (node.$ref) {
+  if (node.$ref !== undefined) {
     if (typeof node.$ref !== "string" || !node.$ref.startsWith("#/$defs/")) {
       errors.push(`$ref at '${path}' must reference '#/$defs/...'`);
     } else {
+      // $ref must not have sibling keywords
+      const siblings = Object.keys(node).filter((k) => k !== "$ref");
+      if (siblings.length > 0) {
+        errors.push(`$ref at '${path}' must not have sibling keywords (found: ${siblings.join(", ")})`);
+      }
       const defName = node.$ref.replace("#/$defs/", "");
-      if (defs && defs[defName]) {
-        if (visited.has(defName)) {
-          return;
-        }
+      if (!defs || !defs[defName]) {
+        errors.push(`$ref at '${path}' points to missing definition '#/$defs/${defName}'`);
+      } else if (!visited.has(defName)) {
         if (anyOfDepth + 1 > 5) {
           errors.push(`anyOf/$ref nesting exceeds 5 levels at '${path}'`);
         } else {
@@ -52,14 +58,48 @@ function walkSchema(node, path, errors, defs, anyOfDepth, propCount, visited = n
   }
 
   // Handle anyOf
-  if (node.anyOf) {
-    if (anyOfDepth + 1 > 5) {
+  if (node.anyOf !== undefined) {
+    if (!Array.isArray(node.anyOf) || node.anyOf.length === 0) {
+      errors.push(`anyOf at '${path}' must be a non-empty array`);
+    } else if (anyOfDepth + 1 > 5) {
       errors.push(`anyOf/$ref nesting exceeds 5 levels at '${path}'`);
     } else {
       node.anyOf.forEach((branch, i) => {
         walkSchema(branch, `${path}.anyOf[${i}]`, errors, defs, anyOfDepth + 1, propCount, visited);
       });
     }
+    return;
+  }
+
+  // enum / const leaves don't require 'type'
+  const hasEnum = node.enum !== undefined;
+  const hasConst = node.const !== undefined;
+
+  if (hasEnum && (!Array.isArray(node.enum) || node.enum.length === 0)) {
+    errors.push(`enum at '${path}' must be a non-empty array`);
+  }
+
+  // Validate 'type' presence and value
+  if (node.type === undefined) {
+    if (!hasEnum && !hasConst) {
+      errors.push(`Schema at '${path}' must define 'type' (or use $ref/anyOf/enum/const)`);
+    }
+  } else if (typeof node.type === "string") {
+    if (!ALLOWED_TYPES.has(node.type)) {
+      errors.push(`Invalid type '${node.type}' at '${path}'`);
+    }
+  } else if (Array.isArray(node.type)) {
+    for (const t of node.type) {
+      if (!ALLOWED_TYPES.has(t)) {
+        errors.push(`Invalid type '${t}' in type array at '${path}'`);
+      }
+    }
+  } else {
+    errors.push(`'type' at '${path}' must be a string or array of strings`);
+  }
+
+  if (node.required !== undefined && !Array.isArray(node.required)) {
+    errors.push(`'required' at '${path}' must be an array`);
   }
 
   // Handle object type
@@ -68,9 +108,19 @@ function walkSchema(node, path, errors, defs, anyOfDepth, propCount, visited = n
       errors.push(`Object at '${path}' must have additionalProperties: false`);
     }
 
-    if (node.properties) {
+    if (!node.properties || typeof node.properties !== "object") {
+      errors.push(`Object at '${path}' must define 'properties'`);
+    } else {
       const propKeys = Object.keys(node.properties);
-      const required = new Set(node.required || []);
+      const propKeySet = new Set(propKeys);
+      const requiredArr = Array.isArray(node.required) ? node.required : [];
+      const required = new Set(requiredArr);
+
+      for (const r of requiredArr) {
+        if (!propKeySet.has(r)) {
+          errors.push(`Required field '${r}' at '${path}' is not defined in properties`);
+        }
+      }
 
       for (const key of propKeys) {
         propCount.count++;
@@ -83,8 +133,12 @@ function walkSchema(node, path, errors, defs, anyOfDepth, propCount, visited = n
   }
 
   // Handle array type
-  if (node.type === "array" && node.items) {
-    walkSchema(node.items, `${path}.items`, errors, defs, anyOfDepth, propCount, visited);
+  if (node.type === "array") {
+    if (!node.items || typeof node.items !== "object" || Array.isArray(node.items)) {
+      errors.push(`Array at '${path}' must define 'items' as a schema object`);
+    } else {
+      walkSchema(node.items, `${path}.items`, errors, defs, anyOfDepth, propCount, visited);
+    }
   }
 }
 


### PR DESCRIPTION
# Fix: stricter OpenAI JSON schema validation

Closes faulty schemas that previously passed [validateOpenAISchema](cci:1://file:///c:/Users/adity/Documents/gtwy-python/node/AI-middleware/src/services/utils/openaiSchemaValidator.utils.js:144:0-180:1).

## Changes
- **Object must define `properties`** when `type: "object"`.
- **`required` entries must exist in `properties`**; `required` must be an array.
- **`type` is mandatory** unless using `$ref` / `anyOf` / `enum` / `const`.
- **`type` value whitelist**: `object, array, string, number, integer, boolean, null` (string or array form).
- **`enum`** must be a non-empty array.
- **`anyOf`** must be a non-empty array.
- **`$ref`** must resolve in `$defs` and have no sibling keywords.
- **`type: "array"`** must define `items` as a schema object.

## Example now caught
```json
{
  "type": "object",
  "required": ["updated", "description"],
  "additionalProperties": false
}
```
Errors: missing `properties`, `required` fields not defined in properties.