### PR TITLE
fix: consumers not working

### DIFF
--- a/src/consumers/index.js
+++ b/src/consumers/index.js
@@ -20,14 +20,20 @@ const CONSUMERS = [
 
 class Consumer {
   constructor(obj, connectionString) {
-    console.log("in contructor ");
     this.queueName = obj.queueName;
     this.processor = obj.process;
     this.bufferSize = obj.batchSize || 1; // Default value if prefetch is not provided
     this.logInInterval = obj.logInInterval || null;
     this.rabbitService = rabbitmqService(connectionString)
       .on("connect", (connection) => this.setup(connection))
-      .on("error", (error) => console.log("[CONSUMER] Error in consumer connection:", error));
+      .on("retry", () => logger.warn(`[CONSUMER] ${this.queueName} - RabbitMQ connection retry in progress...`))
+      .on("error", (error) => logger.error("[CONSUMER] Error in consumer connection:", error));
+
+    // If the connection is already established (event fired before we registered),
+    // call setup immediately so we don't miss it.
+    if (this.rabbitService.status()) {
+      this.setup(this.rabbitService.connection);
+    }
   }
 
   async setup(connection) {
@@ -48,8 +54,7 @@ class Consumer {
         try {
           await this.processor(message, this.channel);
         } catch (error) {
-          console.log(`${this.queueName} Error in consuming`, error);
-          throw error;
+          logger.error(`${this.queueName} Error in consuming`, error);
         }
       },
       { noAck: false }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
+import { configDotenv } from "dotenv";
+configDotenv();
+
 import "express-async-errors";
 import express from "express";
 import cors from "cors";
-import { configDotenv } from "dotenv";
 import "./grafana.js";
 import "./consumers/index.js";
 import "./services/cache.service.js";
@@ -42,7 +44,6 @@ import richUiTemplateRoutes from "./routes/richUiTemplate.routes.js";
 import lagoRoutes from "./routes/lago.routes.js";
 import batchHistoryRoutes from "./routes/batchHistory.routes.js";
 const app = express();
-configDotenv();
 const PORT = process.env.PORT || 7072;
 
 app.use(


### PR DESCRIPTION
## fix: resolve RabbitMQ consumer silent failures

Consumers were silently dying with no errors in logs. Root causes and fixes:

1. **`dotenv` loaded too late** — env vars were `undefined` when consumers initialized. Moved `configDotenv()` before all imports.
2. **`throw error` in consume callback** — was crashing the amqplib channel internally. Removed it; processors already handle their own nack.
3. **Missed `"connect"` event** — the singleton `RabbitConnection` could emit `"connect"` before consumers registered listeners. Added a post-registration check to call `setup()` immediately if already connected. (Unlikely but a defensive safegaurd)
4. **`"retry"` event unhandled** — added listener so connection retries are visible in logs.
5. **`console.log` → `logger`** — all consumer logs now go through the structured logger.

**Files changed:** `src/index.js`, `src/consumers/index.js`