### PR TITLE
Delete api token validation

### DIFF
--- a/src/controllers/agentConfig.controller.js
+++ b/src/controllers/agentConfig.controller.js
@@ -553,11 +553,10 @@ const deleteAgentController = async (req, res, next) => {
 
 const permanentlyDeleteAgentController = async (req, res, next) => {
   const { agent_id } = req.params;
-  const org_id = req.profile.org.id;
   try {
-    const result = await ConfigurationServices.permanentlyDeleteAgent(agent_id, org_id);
+    const result = await ConfigurationServices.permanentlyDeleteAgent(agent_id);
     if (result.success) {
-      console.log(`Permanent delete completed for agent ${agent_id} and ${result.deletedVersionsCount || 0} versions for org ${org_id}`);
+      console.log(`Permanent delete completed for agent ${agent_id} and ${result.deletedVersionsCount || 0} versions.`);
     }
     res.locals = result;
     req.statusCode = result?.success ? 200 : 400;

--- a/src/controllers/agentVersion.controller.js
+++ b/src/controllers/agentVersion.controller.js
@@ -304,7 +304,7 @@ const getVersion = async (req, res, next) => {
   const agent = result.bridges;
   res.locals = {
     success: true,
-    message: "agent get successfully",
+    message: "Version get successfully",
     agent: agent
   };
   req.statusCode = 200;

--- a/src/db_services/configuration.service.js
+++ b/src/db_services/configuration.service.js
@@ -415,11 +415,10 @@ const deleteAgent = async (agent_id, org_id) => {
   }
 };
 
-const permanentlyDeleteAgent = async (agent_id, org_id) => {
+const permanentlyDeleteAgent = async (agent_id) => {
   try {
     const agent = await configurationModel.findOne({
-      _id: new ObjectId(agent_id),
-      org_id: org_id
+      _id: new ObjectId(agent_id)
     });
     if (!agent) {
       return {
@@ -433,7 +432,6 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
       versionModel.aggregate([
         {
           $match: {
-            org_id: org_id,
             connected_agents: { $exists: true, $ne: null }
           }
         },
@@ -457,7 +455,6 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
       configurationModel.aggregate([
         {
           $match: {
-            org_id: org_id,
             connected_agents: { $exists: true, $ne: null }
           }
         },
@@ -485,8 +482,7 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
     if (uniqueAgentIds.length > 0) {
       const connectedAgents = await configurationModel
         .find({
-          _id: { $in: uniqueAgentIds.map((id) => new ObjectId(id)) },
-          org_id: org_id
+          _id: { $in: uniqueAgentIds.map((id) => new ObjectId(id)) }
         })
         .select({ _id: 1, name: 1 })
         .lean();
@@ -514,7 +510,6 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
       : [];
 
     const versionDeleteFilter = {
-      org_id: org_id,
       $or: [{ parent_id: agent_id.toString() }, { parent_id: agent_id }]
     };
     if (versionIdsFromArray.length > 0) {
@@ -525,8 +520,7 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
 
     // Hard delete the agent itself
     const deletedAgent = await configurationModel.deleteOne({
-      _id: new ObjectId(agent_id),
-      org_id: org_id
+      _id: new ObjectId(agent_id)
     });
 
     if (deletedAgent.deletedCount === 0) {

--- a/src/routes/utils.routes.js
+++ b/src/routes/utils.routes.js
@@ -21,7 +21,13 @@ router.get(
 router.post("/token", middleware, validate(utilsValidation.generateToken), utilsController.generateToken);
 router.post("/affiliate/embed-token", middleware, validate(utilsValidation.getAffiliateEmbedToken), utilsController.getAffiliateEmbedToken);
 router.get("/users-details", middleware, utilsController.getCurrentOrgUsers);
-router.delete("/agent/:agent_id", middleware, validate(agentConfigValidation.getAgent), agentConfigController.permanentlyDeleteAgentController);
+router.delete(
+  "/agent/:agent_id",
+  middleware,
+  InternalAuth,
+  validate(agentConfigValidation.getAgent),
+  agentConfigController.permanentlyDeleteAgentController
+);
 router.patch("/models/status", middleware, InternalAuth, validate({ body: setModelStatusAdminBodySchema }), utilsController.setModelStatus);
 router.post("/models/bulk-update", middleware, validate({ body: bulkUpdateUserModelConfigurationBodySchema }), bulkUpdateUserModelConfigurations);
 


### PR DESCRIPTION
Fix Internal Agent Deletion Across Organizations

Previously, the permanent agent deletion API applied an org_id filter while fetching and deleting agents. As a result, internal users could only delete agents belonging to organizations they were members of.

This caused the internal deletion API to fail for agents belonging to other organizations, even when accessed by authorized internal users.