### PR TITLE
fix: remove org restriction from internal agent deletion

### DIFF
--- a/src/controllers/agentConfig.controller.js
+++ b/src/controllers/agentConfig.controller.js
@@ -558,11 +558,10 @@ const deleteAgentController = async (req, res, next) => {
 
 const permanentlyDeleteAgentController = async (req, res, next) => {
   const { agent_id } = req.params;
-  const org_id = req.profile.org.id;
   try {
-    const result = await ConfigurationServices.permanentlyDeleteAgent(agent_id, org_id);
+    const result = await ConfigurationServices.permanentlyDeleteAgent(agent_id);
     if (result.success) {
-      console.log(`Permanent delete completed for agent ${agent_id} and ${result.deletedVersionsCount || 0} versions for org ${org_id}`);
+      console.log(`Permanent delete completed for agent ${agent_id} and ${result.deletedVersionsCount || 0} versions.`);
     }
     res.locals = result;
     req.statusCode = result?.success ? 200 : 400;

--- a/src/db_services/configuration.service.js
+++ b/src/db_services/configuration.service.js
@@ -415,11 +415,10 @@ const deleteAgent = async (agent_id, org_id) => {
   }
 };
 
-const permanentlyDeleteAgent = async (agent_id, org_id) => {
+const permanentlyDeleteAgent = async (agent_id) => {
   try {
     const agent = await configurationModel.findOne({
-      _id: new ObjectId(agent_id),
-      org_id: org_id
+      _id: new ObjectId(agent_id)
     });
     if (!agent) {
       return {
@@ -433,7 +432,6 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
       versionModel.aggregate([
         {
           $match: {
-            org_id: org_id,
             connected_agents: { $exists: true, $ne: null }
           }
         },
@@ -457,7 +455,6 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
       configurationModel.aggregate([
         {
           $match: {
-            org_id: org_id,
             connected_agents: { $exists: true, $ne: null }
           }
         },
@@ -485,8 +482,7 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
     if (uniqueAgentIds.length > 0) {
       const connectedAgents = await configurationModel
         .find({
-          _id: { $in: uniqueAgentIds.map((id) => new ObjectId(id)) },
-          org_id: org_id
+          _id: { $in: uniqueAgentIds.map((id) => new ObjectId(id)) }
         })
         .select({ _id: 1, name: 1 })
         .lean();
@@ -514,7 +510,6 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
       : [];
 
     const versionDeleteFilter = {
-      org_id: org_id,
       $or: [{ parent_id: agent_id.toString() }, { parent_id: agent_id }]
     };
     if (versionIdsFromArray.length > 0) {
@@ -525,8 +520,7 @@ const permanentlyDeleteAgent = async (agent_id, org_id) => {
 
     // Hard delete the agent itself
     const deletedAgent = await configurationModel.deleteOne({
-      _id: new ObjectId(agent_id),
-      org_id: org_id
+      _id: new ObjectId(agent_id)
     });
 
     if (deletedAgent.deletedCount === 0) {


### PR DESCRIPTION
## Summary

Updated the internal permanent agent deletion API to remove the `org_id` restriction.

## Changes Made

* Removed `org_id` dependency from the deletion flow.
* Updated agent lookup and deletion logic to use `agent_id` only.
* Preserved existing authorization and connected-agent validation checks.

## Impact

Authorized internal users can now permanently delete agents across all organizations without being restricted by organization membership.