### PR TITLE
feat: add suggestionCustomPrompt field to agent version and bridge mo…

### DIFF
--- a/src/controllers/agentVersion.controller.js
+++ b/src/controllers/agentVersion.controller.js
@@ -130,7 +130,8 @@ const updateVersionController = async (req, res, next) => {
       "web_search_filters",
       "gtwy_web_search_filters",
       "connected_agent_flow",
-      "variables_state"
+      "variables_state",
+      "suggestionCustomPrompt"
     ];
 
     for (const field of simpleVersionFields) {

--- a/src/db_services/agentVersion.service.js
+++ b/src/db_services/agentVersion.service.js
@@ -420,6 +420,11 @@ async function publish(org_id, version_id, user_id, generate_summary = false) {
   updatedConfiguration.published_version_id = publishedVersionId;
   delete updatedConfiguration.apiCalls; // Remove looked-up data
 
+  // Explicitly copy suggestionCustomPrompt from version to bridge
+  if (getVersionData.suggestionCustomPrompt !== undefined) {
+    updatedConfiguration.suggestionCustomPrompt = getVersionData.suggestionCustomPrompt;
+  }
+
   const publicAgentConfig = parentConfiguration.settings?.publicAgentConfig;
   const environment_config = parentConfiguration.settings?.environment_config;
 

--- a/src/mongoModel/BridgeVersion.model.js
+++ b/src/mongoModel/BridgeVersion.model.js
@@ -237,6 +237,10 @@ const version = new mongoose.Schema({
     type: Boolean,
     default: false
   },
+  suggestionCustomPrompt: {
+    type: String,
+    default: ""
+  },
   updatedAt: {
     type: Date,
     default: Date.now

--- a/src/mongoModel/Configuration.model.js
+++ b/src/mongoModel/Configuration.model.js
@@ -289,6 +289,10 @@ const configuration = new mongoose.Schema({
   cache_on: {
     type: Boolean,
     default: false
+  },
+  suggestionCustomPrompt: {
+    type: String,
+    default: ""
   }
 });
 

--- a/src/services/logQueue/chatbotSuggestions.service.js
+++ b/src/services/logQueue/chatbotSuggestions.service.js
@@ -5,7 +5,17 @@ import { bridge_ids } from "../../configs/constant.js";
 import prebuiltPromptDbService from "../../db_services/prebuiltPrompt.service.js";
 import logger from "../../logger.js";
 
-async function chatbotSuggestions({ response_format, assistant, user, bridge_summary, thread_id, sub_thread_id, configuration, org_id }) {
+async function chatbotSuggestions({
+  response_format,
+  assistant,
+  user,
+  bridge_summary,
+  thread_id,
+  sub_thread_id,
+  configuration,
+  org_id,
+  suggestionCustomPrompt
+}) {
   try {
     const prompt_summary = bridge_summary;
     const prompt = configuration?.prompt;
@@ -25,7 +35,10 @@ async function chatbotSuggestions({ response_format, assistant, user, bridge_sum
     }
 
     const message = `Generate suggestions based on the user conversations. \n **User Conversations**: ${JSON.stringify(conversation.slice(-2))}`;
-    const variables = { prompt_summary: final_prompt };
+    const variables = {
+      prompt_summary: final_prompt,
+      suggestionCustomPrompt: suggestionCustomPrompt
+    };
     const composed_thread_id = `${thread_id || random_id}-${sub_thread_id || random_id}`;
 
     const result = await callAiMiddleware(message, bridge_ids.chatbot_suggestions, variables, ai_configuration, null, composed_thread_id);

--- a/src/validation/joi_validation/bridgeVersion.validation.js
+++ b/src/validation/joi_validation/bridgeVersion.validation.js
@@ -1,6 +1,7 @@
 import Joi from "joi";
 
 const updateVersionSchema = Joi.object({
+  suggestionCustomPrompt: Joi.alternatives().try(Joi.string().allow(""), Joi.object()).optional(),
   configuration: Joi.object({
     model: Joi.string().optional(),
     type: Joi.string().valid("chat", "embedding", "fine-tune", "reasoning", "image").optional(),
@@ -50,7 +51,8 @@ const updateVersionSchema = Joi.object({
     punctuate: Joi.alternatives().try(Joi.boolean(), Joi.string(), Joi.object()).optional(),
     numerals: Joi.alternatives().try(Joi.boolean(), Joi.string(), Joi.object()).optional(),
     detect_entities: Joi.alternatives().try(Joi.boolean(), Joi.string(), Joi.object()).optional(),
-    model_option: Joi.alternatives().try(Joi.string().allow(""), Joi.object()).optional()
+    model_option: Joi.alternatives().try(Joi.string().allow(""), Joi.object()).optional(),
+    suggestionCustomPrompt: Joi.alternatives().try(Joi.string().allow(""), Joi.object()).optional()
   }).optional(),
   service: Joi.string()
     .valid("openai", "anthropic", "groq", "open_router", "mistral", "gemini", "grok", "deepgram", "neev_cloud", "moonshot")


### PR DESCRIPTION
…dels

- Add suggestionCustomPrompt field to BridgeVersion and Configuration models with string type and empty default
- Include suggestionCustomPrompt in updateVersionController's simpleVersionFields array
- Explicitly copy suggestionCustomPrompt from version to bridge during publish operation
- Pass suggestionCustomPrompt to chatbotSuggestions service and include in variables object
- Add validation for suggestionCustomPrompt in