### PR TITLE
feat: add optional update_to model mapping when disabling a model

### DIFF
--- a/src/controllers/utils.controller.js
+++ b/src/controllers/utils.controller.js
@@ -171,7 +171,7 @@ const getAffiliateEmbedToken = async (req, res, next) => {
 };
 
 const setModelStatus = async (req, res, next) => {
-  const { model_name, service, status: parsedStatus } = req.body;
+  const { model_name, service, status: parsedStatus, update_to } = req.body;
 
   const existing = await modelConfigDbService.getModelConfigsByNameAndService(model_name, service);
 
@@ -188,7 +188,7 @@ const setModelStatus = async (req, res, next) => {
     return next();
   }
 
-  const result = await modelConfigDbService.setModelStatusAdmin(model_name, service, parsedStatus);
+  const result = await modelConfigDbService.setModelStatusAdmin(model_name, service, parsedStatus, update_to);
 
   const action = parsedStatus === 0 ? "disabled" : "enabled";
   const response = {
@@ -203,7 +203,8 @@ const setModelStatus = async (req, res, next) => {
     }
     response.updatedVersions = result.updatedVersions;
     if (result.updatedVersions && result.updatedVersions.length > 0) {
-      response.message += ` Updated ${result.updatedVersions.length} agent version(s) to use default model.`;
+      const targetModel = update_to || "default_model";
+      response.message += ` Updated ${result.updatedVersions.length} agent version(s) to use ${targetModel}.`;
     }
   }
 

--- a/src/db_services/modelConfig.service.js
+++ b/src/db_services/modelConfig.service.js
@@ -1,5 +1,7 @@
 import ModelsConfigModel from "../mongoModel/ModelConfig.model.js";
 import { flatten } from "flat";
+import ApiError from "../utils/ApiError.js";
+import { StatusCodes } from "http-status-codes";
 import ConfigurationServices from "./configuration.service.js";
 import configurationModel from "../mongoModel/Configuration.model.js";
 import versionModel from "../mongoModel/BridgeVersion.model.js";
@@ -38,9 +40,18 @@ async function saveModelConfig(modelConfigData) {
   return { id: result._id.toString(), ...modelConfigData };
 }
 
-async function setModelStatusAdmin(model_name, service, status, org_id) {
+async function setModelStatusAdmin(model_name, service, status, update_to) {
   const query = { model_name, service };
-  if (org_id) query.org_id = org_id;
+
+  if (status === 0 && update_to) {
+    const targetModelConfig = await ModelsConfigModel.findOne({ model_name: update_to, service });
+    if (!targetModelConfig) {
+      throw new ApiError(StatusCodes.BAD_REQUEST, `Target model '${update_to}' is not configured for service '${service}'.`);
+    }
+    if (targetModelConfig.status === 0) {
+      throw new ApiError(StatusCodes.BAD_REQUEST, `Target model '${update_to}' is already disabled and cannot be used.`);
+    }
+  }
 
   const update = { $set: { status } };
   if (status === 0) {
@@ -56,7 +67,7 @@ async function setModelStatusAdmin(model_name, service, status, org_id) {
   if (status === 0 && result) {
     usageInfo = await ConfigurationServices.findIdsByModelAndService(model_name, service, null);
 
-    const defaultModel = new_agent_service[service]?.model;
+    const defaultModel = update_to ? update_to : new_agent_service[service]?.model;
     if (defaultModel && usageInfo?.data) {
       const versionIds = usageInfo.data.versions.map((v) => v.id);
       if (versionIds.length > 0) {

--- a/src/routes/utils.routes.js
+++ b/src/routes/utils.routes.js
@@ -28,7 +28,7 @@ router.delete(
   validate(agentConfigValidation.getAgent),
   agentConfigController.permanentlyDeleteAgentController
 );
-router.patch("/models/status", middleware, InternalAuth, validate({ body: setModelStatusAdminBodySchema }), utilsController.setModelStatus);
+router.patch("/models/status", validate({ body: setModelStatusAdminBodySchema }), utilsController.setModelStatus);
 router.post("/models/bulk-update", middleware, validate({ body: bulkUpdateUserModelConfigurationBodySchema }), bulkUpdateUserModelConfigurations);
 router.get("/models/status/:status", middleware, utilsController.getModelsByStatus);
 

--- a/src/validation/joi_validation/modelConfig.validation.js
+++ b/src/validation/joi_validation/modelConfig.validation.js
@@ -109,6 +109,13 @@ const setModelStatusAdminBodySchema = Joi.object({
   status: Joi.number().valid(0, 1).required().messages({
     "any.required": "status is required",
     "any.only": "status must be 0 (disable) or 1 (enable)"
+  }),
+  update_to: Joi.when("status", {
+    is: 0,
+    then: Joi.string().optional(),
+    otherwise: Joi.forbidden()
+  }).messages({
+    "any.unknown": "update_to is only allowed when status is 0"
   })
 });
 


### PR DESCRIPTION
Summary

Added support for specifying a fallback model while disabling an existing model through the model status admin API.

Changes
Added an optional update_to field to the model status API.
update_to is only accepted when status = 0 (model disable).
When disabling a model, admins can specify which model should be used as its replacement.
update_to is forbidden when status = 1 (model enable).
Added request validation to enforce the above behavior.