### PR TITLE
fix: load InternalAuth allowlist from env instead of hardcoding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@ METRICS_QUEUE_NAME=AI-Middleware-metrics
 JWT_SECRET=your_jwt_secret_key_here
 JWT_EXPIRES_IN=7d
 
+# Internal admin APIs (comma-separated emails, no spaces required)
+INTERNAL_ALLOWED_EMAILS=admin1@example.com,admin2@example.com
+
 # CORS Configuration
 CORS_ORIGIN=http://localhost:3001
 

--- a/src/middlewares/middleware.js
+++ b/src/middlewares/middleware.js
@@ -322,16 +322,21 @@ const EmbeddecodeToken = async (req, res, next) => {
   }
 };
 
+const INTERNAL_ALLOWED_EMAILS = new Set(
+  (process.env.INTERNAL_ALLOWED_EMAILS || "")
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean)
+);
+
 const InternalAuth = async (req, res, next) => {
   try {
-    const allowedEmailList = ["ankit@whozzat.com", "husain@whozzat.com", "harsh@whozzat.com"];
-
     const userEmail = req.profile?.user?.email?.toLowerCase();
     if (!userEmail) {
       return res.status(403).json({ success: false, message: "Access denied: email not found in token" });
     }
 
-    if (!allowedEmailList.includes(userEmail)) {
+    if (!INTERNAL_ALLOWED_EMAILS.has(userEmail)) {
       return res.status(403).json({ success: false, message: "Access denied: you are not authorized for this action" });
     }
 


### PR DESCRIPTION
Description
InternalAuth previously allowed only a hardcoded list of emails in source. That exposed privileged emails in the repo and made updates require a code change.

This change reads the allowlist from INTERNAL_ALLOWED_EMAILS (comma-separated) at startup into a Set, so:

emails stay out of source control
no DB call is needed
allowlist can be updated via env/secrets without redeploying code changes for the list itself
Also documents the variable in .env.example.