### PR TITLE
refactor: added gpt memory tool

### DIFF
--- a/src/services/logQueue/handleGptMemory.service.js
+++ b/src/services/logQueue/handleGptMemory.service.js
@@ -4,9 +4,49 @@ import prebuiltPromptDbService from "../../db_services/prebuiltPrompt.service.js
 import { refreshGptMemoryCache } from "../utils/gptMemory.service.js";
 import logger from "../../logger.js";
 
+const PAGES_HINT =
+  "Store and update long-term memory as JSON with shape " +
+  '{"version":2,"pages":{ "<your_key>": <value>, ... }}. ' +
+  "You decide the page keys and nested structure based on what is useful to remember. " +
+  "Merge new information into the relevant pages; do not wipe unrelated pages. " +
+  "Prefer structured fields over free-text blobs.";
+
+const EMPTY_PAGES_MEMORY = {
+  version: 2,
+  pages: {}
+};
+
 function normalizeContent(value) {
   if (value && typeof value === "object") return JSON.stringify(value);
   return value ?? "";
+}
+
+/**
+ * Build the JSON string injected into the memory agent's `json_format` prompt variable.
+ * Always page-shaped: { version, pages: { ... } }.
+ */
+function buildJsonFormatVariable(purpose) {
+  if (purpose == null || purpose === "") {
+    return JSON.stringify(EMPTY_PAGES_MEMORY);
+  }
+
+  if (typeof purpose === "object" && !Array.isArray(purpose)) {
+    if (purpose.pages && typeof purpose.pages === "object") {
+      return JSON.stringify({
+        version: purpose.version ?? 2,
+        pages: purpose.pages,
+        ...(purpose.updated_at != null ? { updated_at: purpose.updated_at } : {})
+      });
+    }
+    // Top-level content dict → treat as pages
+    return JSON.stringify({ version: 2, pages: purpose });
+  }
+
+  // Legacy free-text memory
+  return JSON.stringify({
+    version: 2,
+    pages: { legacy: String(purpose) }
+  });
 }
 
 function buildConversation(pendingTurns, user, assistant) {
@@ -20,6 +60,13 @@ function buildConversation(pendingTurns, user, assistant) {
     { role: "user", content: normalizeContent(user) },
     { role: "assistant", content: normalizeContent(content) }
   ];
+}
+
+function resolveGptMemoryAgentOptions() {
+  const bridgeId = (process.env.GPT_MEMORY_BRIDGE_ID || "").trim() || bridge_ids.gpt_memory;
+  const environment = (process.env.GPT_MEMORY_ENVIRONMENT || "").trim() || null;
+  const versionId = (process.env.GPT_MEMORY_VERSION_ID || "").trim() || null;
+  return { bridgeId, environment, versionId };
 }
 
 async function handleGptMemory({
@@ -37,10 +84,11 @@ async function handleGptMemory({
   version_id
 }) {
   try {
-    const memoryVar = purpose && typeof purpose === "object" ? JSON.stringify(purpose) : purpose;
+    const jsonFormat = buildJsonFormatVariable(purpose);
     const variables = {
       threadID: id,
-      memory: memoryVar,
+      memory: jsonFormat,
+      json_format: jsonFormat,
       gpt_memory_context,
       bridge_summary: bridge_summary || ""
     };
@@ -56,9 +104,18 @@ async function handleGptMemory({
 
     const bridgeContext = bridge_summary ? `Context about the main agent you are storing memory for:\n${bridge_summary}\n\n` : "";
     const memoryContext = gpt_memory_context ? `\n\nMemory storage instructions: ${gpt_memory_context}` : "";
-    const message = `${bridgeContext}\n\n${memoryContext}`;
+    const message = `${bridgeContext}${PAGES_HINT}${memoryContext}`;
 
-    const response = await callAiMiddleware(message, bridge_ids.gpt_memory, variables, configuration, "text");
+    const { bridgeId, environment, versionId } = resolveGptMemoryAgentOptions();
+
+    const response = await callAiMiddleware(message, {
+      bridge_id: bridgeId,
+      variables,
+      configuration,
+      response_type: "text",
+      environment,
+      version_id: versionId
+    });
 
     if (response === "True") {
       try {
@@ -68,7 +125,11 @@ async function handleGptMemory({
           sub_thread_id,
           version_id
         });
-        logger.info(`handleGptMemory: memory updated via tool for ${id}, refreshed cache ${memoryId}`);
+        logger.info(
+          `handleGptMemory: memory updated via tool for ${id}, refreshed cache ${memoryId}` +
+            (environment ? `, environment=${environment}` : "") +
+            (versionId ? `, version_id=${versionId}` : "")
+        );
       } catch (cacheErr) {
         logger.error(`handleGptMemory: failed to refresh cache for ${id}: ${cacheErr.message}`);
       }

--- a/src/services/utils/aiCall.utils.js
+++ b/src/services/utils/aiCall.utils.js
@@ -2,19 +2,45 @@ import axios from "axios";
 import { configDotenv } from "dotenv";
 configDotenv();
 
-async function callAiMiddleware(
-  user,
-  bridge_id,
-  variables = {},
-  configuration = null,
-  response_type = null,
-  thread_id = null,
-  orchestrator_flag = false
-) {
+/**
+ * Call GTWY chat/completion for an internal agent.
+ *
+ * Positional (legacy):
+ *   callAiMiddleware(user, bridge_id, variables, configuration, response_type, thread_id, orchestrator_flag)
+ *
+ * Options object (preferred when passing environment / version_id):
+ *   callAiMiddleware(user, { bridge_id, variables, configuration, response_type, thread_id, orchestrator_flag, environment, version_id })
+ */
+async function callAiMiddleware(user, bridgeIdOrOptions, ...rest) {
+  let bridge_id;
+  let variables = {};
+  let configuration = null;
+  let response_type = null;
+  let thread_id = null;
+  let orchestrator_flag = false;
+  let environment = null;
+  let version_id = null;
+
+  if (bridgeIdOrOptions && typeof bridgeIdOrOptions === "object" && !Array.isArray(bridgeIdOrOptions)) {
+    ({
+      bridge_id,
+      variables = {},
+      configuration = null,
+      response_type = null,
+      thread_id = null,
+      orchestrator_flag = false,
+      environment = null,
+      version_id = null
+    } = bridgeIdOrOptions);
+  } else {
+    bridge_id = bridgeIdOrOptions;
+    [variables = {}, configuration = null, response_type = null, thread_id = null, orchestrator_flag = false] = rest;
+  }
+
   const requestBody = {
-    user: user,
-    bridge_id: bridge_id,
-    variables: variables
+    user,
+    bridge_id,
+    variables
   };
 
   if (response_type !== null) {
@@ -31,6 +57,14 @@ async function callAiMiddleware(
 
   if (orchestrator_flag) {
     requestBody.orchestrator_flag = orchestrator_flag;
+  }
+
+  if (environment) {
+    requestBody.environment = environment;
+  }
+
+  if (version_id) {
+    requestBody.version_id = version_id;
   }
 
   try {


### PR DESCRIPTION
Always inject page-shaped memory into writer variables (json_format, memory)
Add pages hint so writer merges into useful page keys
Support empty { version: 2, pages: {} } starting point
On "True", refresh Redis cache for the thread memory id
Support options object including environment / version_id for internal memory-agent calls