### PR TITLE
Agent config http res flag

### DIFF
--- a/src/controllers/agentConfig.controller.js
+++ b/src/controllers/agentConfig.controller.js
@@ -14,7 +14,9 @@ import { ResponseSender } from "../services/utils/customResponse.utils.js";
 
 const responseSender = new ResponseSender();
 
-const createAgentInBackground = async (req, { useRtLayer = true } = {}) => {
+const createAgentInBackground = async (req) => {
+  // flag=true → return agent in HTTP response; flag=false → notify via RTLayer
+  const flag = req.body?.flag === true;
   let user_id = req.profile.user.id;
   const org_id = req.profile.org.id;
   const rtChannel = `org_${org_id}_${user_id}`;
@@ -262,7 +264,7 @@ const createAgentInBackground = async (req, { useRtLayer = true } = {}) => {
       });
     }
 
-    if (useRtLayer) {
+    if (!flag) {
       await responseSender.sendResponse({
         ...rtResponseBase,
         data: { type: "agent_created", user_id, agent }
@@ -272,7 +274,7 @@ const createAgentInBackground = async (req, { useRtLayer = true } = {}) => {
 
     return { agent, user_id };
   } catch (e) {
-    if (useRtLayer) {
+    if (!flag) {
       await responseSender
         .sendResponse({
           ...rtResponseBase,
@@ -290,23 +292,18 @@ const createAgentInBackground = async (req, { useRtLayer = true } = {}) => {
 };
 
 const createAgentController = async (req, res, next) => {
-  const httpResponse = req.body?.http_response === true;
+  const flag = req.body?.flag === true;
 
-  if (httpResponse) {
-    try {
-      const result = await createAgentInBackground(req, { useRtLayer: false });
-      res.locals = { success: true, agent: result.agent };
-      req.statusCode = 200;
-    } catch (e) {
-      res.locals = { success: false, message: e.message || "Error in creating agent" };
-      req.statusCode = 500;
-    }
+  if (flag) {
+    const result = await createAgentInBackground(req);
+    res.locals = { success: true, agent: result.agent };
+    req.statusCode = 200;
     return next();
   }
 
   res.locals = { success: true, accepted: true, message: "Agent creation started" };
   req.statusCode = 202;
-  createAgentInBackground(req, { useRtLayer: true });
+  createAgentInBackground(req);
   return next();
 };
 

--- a/src/controllers/agentConfig.controller.js
+++ b/src/controllers/agentConfig.controller.js
@@ -14,7 +14,7 @@ import { ResponseSender } from "../services/utils/customResponse.utils.js";
 
 const responseSender = new ResponseSender();
 
-const createAgentInBackground = async (req) => {
+const createAgentInBackground = async (req, { useRtLayer = true } = {}) => {
   let user_id = req.profile.user.id;
   const org_id = req.profile.org.id;
   const rtChannel = `org_${org_id}_${user_id}`;
@@ -262,28 +262,51 @@ const createAgentInBackground = async (req) => {
       });
     }
 
-    await responseSender.sendResponse({
-      ...rtResponseBase,
-      data: { type: "agent_created", user_id, agent }
-    });
-  } catch (e) {
-    await responseSender
-      .sendResponse({
+    if (useRtLayer) {
+      await responseSender.sendResponse({
         ...rtResponseBase,
-        data: {
-          type: "agent_create_failed",
-          user_id,
-          message: e.message || "Error in creating agent"
-        }
-      })
-      .catch((rtErr) => console.error("RT agent create error notify failed:", rtErr.message));
+        data: { type: "agent_created", user_id, agent }
+      });
+      return;
+    }
+
+    return { agent, user_id };
+  } catch (e) {
+    if (useRtLayer) {
+      await responseSender
+        .sendResponse({
+          ...rtResponseBase,
+          data: {
+            type: "agent_create_failed",
+            user_id,
+            message: e.message || "Error in creating agent"
+          }
+        })
+        .catch((rtErr) => console.error("RT agent create error notify failed:", rtErr.message));
+      return;
+    }
+    throw e;
   }
 };
 
 const createAgentController = async (req, res, next) => {
+  const httpResponse = req.body?.http_response === true;
+
+  if (httpResponse) {
+    try {
+      const result = await createAgentInBackground(req, { useRtLayer: false });
+      res.locals = { success: true, agent: result.agent };
+      req.statusCode = 200;
+    } catch (e) {
+      res.locals = { success: false, message: e.message || "Error in creating agent" };
+      req.statusCode = 500;
+    }
+    return next();
+  }
+
   res.locals = { success: true, accepted: true, message: "Agent creation started" };
   req.statusCode = 202;
-  createAgentInBackground(req);
+  createAgentInBackground(req, { useRtLayer: true });
   return next();
 };
 

--- a/src/validation/joi_validation/agentConfig.validation.js
+++ b/src/validation/joi_validation/agentConfig.validation.js
@@ -15,7 +15,7 @@ const createBridgeSchema = Joi.object({
   bridge_limit_start_date: Joi.date().optional(),
   folder_id: Joi.string().allow(null).optional(),
   // When true, await create and return the agent in the HTTP response instead of RTLayer.
-  http_response: Joi.boolean().optional().default(false)
+  flag: Joi.boolean().optional().default(false)
 }).unknown(true); // Allow additional fields that might be added dynamically
 
 const updateBridgeSchema = Joi.object({

--- a/src/validation/joi_validation/agentConfig.validation.js
+++ b/src/validation/joi_validation/agentConfig.validation.js
@@ -13,7 +13,9 @@ const createBridgeSchema = Joi.object({
   bridge_usage: Joi.number().min(0).optional(),
   bridge_limit_reset_period: Joi.string().valid("monthly", "weekly", "daily").optional(),
   bridge_limit_start_date: Joi.date().optional(),
-  folder_id: Joi.string().allow(null).optional()
+  folder_id: Joi.string().allow(null).optional(),
+  // When true, await create and return the agent in the HTTP response instead of RTLayer.
+  http_response: Joi.boolean().optional().default(false)
 }).unknown(true); // Allow additional fields that might be added dynamically
 
 const updateBridgeSchema = Joi.object({


### PR DESCRIPTION
added an http_response flag: when true, await creation and return the agent over HTTP; otherwise keep the existing 202 + RTLayer flow.